### PR TITLE
 Improve structured document import and add worker cancellation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,20 @@ in the document import dialog. If the active interpreter is missing one of those
 packages, the app shows a startup/import warning and asks you to run
 `poetry install`.
 
+## Version Bumping
+
+To have VS Code commits automatically bump the patch version in
+`pyproject.toml`, install the local pre-commit hook:
+
+```powershell
+.\scripts\version\install_pre_commit_hook.ps1
+```
+
+After installation, commits that include staged changes under `app/`, `docs/`,
+`scripts/`, `tests/`, or `README.md` will bump and stage `pyproject.toml`.
+Commits that already include a staged `pyproject.toml` version change are left
+alone.
+
 ## Running The App
 
 You can launch the application in either of these ways:
@@ -98,6 +112,8 @@ These controls are applied to both the SSML preview and generated audio.
 `Import Document` opens a structured import dialog with:
 
 - a row-based preview of extracted document sections
+- heading-aware rows for DOCX, HTML, and EPUB content where available
+- table and spreadsheet rows that keep sheet, column, and table context
 - multi-row selection
 - content modes:
   - `Prefer Secondary Text`
@@ -109,6 +125,7 @@ From that dialog you can:
 
 - import the selected rows into the main editor
 - batch export the selected rows to one `.mp3` per item
+- cancel active document-load or batch-export work without closing the app
 
 ## Logging
 

--- a/app/controller/background_workers.py
+++ b/app/controller/background_workers.py
@@ -68,17 +68,30 @@ class DocumentParseWorker(QObject):
 
     finished = pyqtSignal(object)
     failed = pyqtSignal(str)
+    cancelled = pyqtSignal()
 
     def __init__(self, file_path):
         super().__init__()
         self.file_path = file_path
+        self._cancel_requested = False
+
+    def request_cancel(self):
+        self._cancel_requested = True
 
     def run(self):
+        if self._cancel_requested:
+            self.cancelled.emit()
+            return
+
         try:
             rows = DocumentScraper().scrape_file(self.file_path)
         except Exception as error:
             logger.exception("Document parsing failed for {}: {}", self.file_path, error)
             self.failed.emit(str(error))
+            return
+
+        if self._cancel_requested:
+            self.cancelled.emit()
             return
 
         self.finished.emit(rows)
@@ -90,6 +103,7 @@ class BatchExportWorker(QObject):
     progress = pyqtSignal(int, int, str)
     finished = pyqtSignal(object)
     failed = pyqtSignal(str, object)
+    cancelled = pyqtSignal(object)
 
     def __init__(self, rows, output_dir, settings, azure_key, azure_region):
         super().__init__()
@@ -98,10 +112,18 @@ class BatchExportWorker(QObject):
         self.settings = AppSettings(**vars(settings))
         self.azure_key = azure_key
         self.azure_region = azure_region
+        self._cancel_requested = False
+
+    def request_cancel(self):
+        self._cancel_requested = True
 
     def run(self):
         exported_files = []
         try:
+            if self._cancel_requested:
+                self.cancelled.emit(exported_files)
+                return
+
             if not self.azure_key or not self.azure_region:
                 raise RuntimeError("Azure Speech credentials are required.")
 
@@ -118,9 +140,17 @@ class BatchExportWorker(QObject):
             total_rows = len(exportable_rows)
 
             for row_index, row in enumerate(exportable_rows, start=1):
+                if self._cancel_requested:
+                    self.cancelled.emit(exported_files)
+                    return
+
                 resolved_text = (row.get("resolved_text") or "").strip()
                 ssml = build_ssml_document(resolved_text, self.settings, cleaner)
                 audio_data = processor.text_to_speech(ssml, use_ssml=True)
+
+                if self._cancel_requested:
+                    self.cancelled.emit(exported_files)
+                    return
 
                 mode_name = sanitize_batch_name(row.get("content_mode", "prefer_notes"))
                 title_name = sanitize_batch_name(

--- a/app/controller/main_controller.py
+++ b/app/controller/main_controller.py
@@ -85,6 +85,7 @@ class MainController(QObject):
         self.view.playButton.clicked.connect(self.generate_and_play_audio)
         self.view.generateButton.clicked.connect(self.export_audio_file)
         self.view.stopButton.clicked.connect(self.stop_audio)
+        self.view.cancelTaskButton.clicked.connect(self.cancel_background_work)
         self.view.playbackVolumeSlider.valueChanged.connect(
             self.update_playback_volume
         )
@@ -159,6 +160,7 @@ class MainController(QObject):
         self.view.actionExportAudio.setEnabled(has_text)
         self.view.stopButton.setEnabled(multimedia_available and has_preview_audio)
         self.view.playbackVolumeSlider.setEnabled(multimedia_available)
+        self.view.cancelTaskButton.setEnabled(background_work_active)
 
         if multimedia_available:
             self.view.playButton.setText("Generate && Play")
@@ -178,10 +180,13 @@ class MainController(QObject):
             self.view.generateButton.setEnabled(False)
             self.view.actionExportAudio.setEnabled(False)
             self.view.stopButton.setEnabled(False)
+            self.view.openSecondWindowButton.setEnabled(False)
             self._set_inline_hint(
-                "Background work is running. Generation actions will unlock when it finishes."
+                "Background work is running. Use Cancel Task if you need to stop it."
             )
             return
+
+        self.view.openSecondWindowButton.setEnabled(True)
 
         if not has_text:
             self._set_inline_hint(
@@ -547,10 +552,15 @@ class MainController(QObject):
         self.batch_export_worker.progress.connect(self._handle_batch_export_progress)
         self.batch_export_worker.finished.connect(self._handle_batch_export_finished)
         self.batch_export_worker.failed.connect(self._handle_batch_export_failed)
+        self.batch_export_worker.cancelled.connect(self._handle_batch_export_cancelled)
         self.batch_export_worker.finished.connect(self.batch_export_thread.quit)
         self.batch_export_worker.failed.connect(self.batch_export_thread.quit)
+        self.batch_export_worker.cancelled.connect(self.batch_export_thread.quit)
         self.batch_export_worker.finished.connect(self.batch_export_worker.deleteLater)
         self.batch_export_worker.failed.connect(self.batch_export_worker.deleteLater)
+        self.batch_export_worker.cancelled.connect(
+            self.batch_export_worker.deleteLater
+        )
         self.batch_export_thread.finished.connect(self.batch_export_thread.deleteLater)
         self.batch_export_thread.finished.connect(self._clear_batch_export_worker)
         self.batch_export_thread.start()
@@ -617,11 +627,53 @@ class MainController(QObject):
             f"Unable to finish batch export.\n\n{message}",
         )
 
+    def _handle_batch_export_cancelled(self, exported_files):
+        self.batch_export_active = False
+        exported_paths = [Path(file_path) for file_path in exported_files]
+        for file_path in exported_paths:
+            self.latest_audio_path = str(file_path)
+            self._record_audio_history(file_path, "export")
+
+        self.view.statusbar.showMessage(
+            f"Batch export canceled after {len(exported_paths)} completed file(s)."
+        )
+        QMessageBox.information(
+            self.view,
+            "Batch Export Canceled",
+            f"Created {len(exported_paths)} audio file(s) before cancellation.",
+        )
+        logger.info(
+            "Batch export canceled after {} completed files.",
+            len(exported_paths),
+        )
+
     def _clear_batch_export_worker(self):
         self.batch_export_thread = None
         self.batch_export_worker = None
         self.batch_export_active = False
         self._refresh_action_states()
+
+    def cancel_background_work(self):
+        cancel_requested = False
+
+        if self.batch_export_worker is not None:
+            self.batch_export_worker.request_cancel()
+            cancel_requested = True
+
+        if self.document_parse_worker is not None:
+            self.document_parse_worker.request_cancel()
+            cancel_requested = True
+
+        if not cancel_requested:
+            self.view.statusbar.showMessage("No background task is running.")
+            self._refresh_action_states()
+            return
+
+        self.view.cancelTaskButton.setEnabled(False)
+        self.view.statusbar.showMessage(
+            "Cancel requested. The current worker step will stop when safe."
+        )
+        logger.info("Requested cancellation for active background work.")
 
     def update_playback_volume(self, value):
         self.settings.playback_volume = value
@@ -659,12 +711,19 @@ class MainController(QObject):
             self._handle_document_parse_finished
         )
         self.document_parse_worker.failed.connect(self._handle_document_parse_failed)
+        self.document_parse_worker.cancelled.connect(
+            self._handle_document_parse_cancelled
+        )
         self.document_parse_worker.finished.connect(self.document_parse_thread.quit)
         self.document_parse_worker.failed.connect(self.document_parse_thread.quit)
+        self.document_parse_worker.cancelled.connect(self.document_parse_thread.quit)
         self.document_parse_worker.finished.connect(
             self.document_parse_worker.deleteLater
         )
         self.document_parse_worker.failed.connect(
+            self.document_parse_worker.deleteLater
+        )
+        self.document_parse_worker.cancelled.connect(
             self.document_parse_worker.deleteLater
         )
         self.document_parse_thread.finished.connect(
@@ -705,6 +764,10 @@ class MainController(QObject):
             f"Unable to read the selected document.\n\n{message}",
         )
         self.view.statusbar.showMessage("Document load failed.")
+
+    def _handle_document_parse_cancelled(self):
+        self.view.statusbar.showMessage("Document load canceled.")
+        logger.info("Document load canceled.")
 
     def _clear_document_parse_worker(self):
         self.document_parse_thread = None

--- a/app/controller/second_controller.py
+++ b/app/controller/second_controller.py
@@ -27,6 +27,7 @@ class SecondController(QObject):
         self.load_worker = None
         self.view.browseButton.clicked.connect(self.choose_file)
         self.view.loadButton.clicked.connect(self.load_file)
+        self.view.cancelLoadButton.clicked.connect(self.cancel_load)
         self.view.importButton.clicked.connect(self.import_text)
         self.view.batchExportButton.clicked.connect(self.batch_export)
         self.view.selectAllButton.clicked.connect(self.view.previewTable.selectAll)
@@ -101,10 +102,11 @@ class SecondController(QObject):
             "clearSelectionButton",
         ):
             getattr(self.view, button_name).setEnabled(not is_loading)
+        self.view.cancelLoadButton.setEnabled(is_loading)
 
         if is_loading:
             self.view.infoLabel.setText(
-                "Loading document in the background. You can keep the app open."
+                "Loading document in the background. You can cancel this load if needed."
             )
 
     def _surface_document_dependency_status(self):
@@ -149,14 +151,28 @@ class SecondController(QObject):
         self.load_thread.started.connect(self.load_worker.run)
         self.load_worker.finished.connect(self._handle_load_finished)
         self.load_worker.failed.connect(self._handle_load_failed)
+        self.load_worker.cancelled.connect(self._handle_load_cancelled)
         self.load_worker.finished.connect(self.load_thread.quit)
         self.load_worker.failed.connect(self.load_thread.quit)
+        self.load_worker.cancelled.connect(self.load_thread.quit)
         self.load_worker.finished.connect(self.load_worker.deleteLater)
         self.load_worker.failed.connect(self.load_worker.deleteLater)
+        self.load_worker.cancelled.connect(self.load_worker.deleteLater)
         self.load_thread.finished.connect(self.load_thread.deleteLater)
         self.load_thread.finished.connect(self._clear_load_worker)
         self.load_thread.start()
         logger.info("Started background import for document file {}", file_path)
+
+    def cancel_load(self):
+        if self.load_worker is None:
+            return
+
+        self.load_worker.request_cancel()
+        self.view.cancelLoadButton.setEnabled(False)
+        self.view.infoLabel.setText(
+            "Cancel requested. The current parser step will stop when safe."
+        )
+        logger.info("Requested cancellation for document import.")
 
     def _handle_load_finished(self, extracted_rows):
         self.import_rows = extracted_rows
@@ -179,6 +195,10 @@ class SecondController(QObject):
             "Import Error",
             f"Unable to read the selected document.\n\n{message}",
         )
+
+    def _handle_load_cancelled(self):
+        self.view.infoLabel.setText("Document import canceled.")
+        logger.info("Document import canceled.")
 
     def _clear_load_worker(self):
         self.load_thread = None

--- a/app/gui/ui_main_window.py
+++ b/app/gui/ui_main_window.py
@@ -37,6 +37,8 @@ class Ui_MainWindow:
         self.playButton = QPushButton("Generate && Play", self.audioControlsGroup)
         self.generateButton = QPushButton("Generate File", self.audioControlsGroup)
         self.stopButton = QPushButton("Stop", self.audioControlsGroup)
+        self.cancelTaskButton = QPushButton("Cancel Task", self.audioControlsGroup)
+        self.cancelTaskButton.setEnabled(False)
         self.openSecondWindowButton = QPushButton(
             "Import Document",
             self.audioControlsGroup,
@@ -51,6 +53,7 @@ class Ui_MainWindow:
             self.playButton,
             self.generateButton,
             self.stopButton,
+            self.cancelTaskButton,
             self.openSecondWindowButton,
             self.openSettingsButton,
         ):

--- a/app/gui/ui_second_window.py
+++ b/app/gui/ui_second_window.py
@@ -32,9 +32,12 @@ class Ui_Dialog:
         )
         self.browseButton = QPushButton("Browse", dialog)
         self.loadButton = QPushButton("Load", dialog)
+        self.cancelLoadButton = QPushButton("Cancel Load", dialog)
+        self.cancelLoadButton.setEnabled(False)
         path_row.addWidget(self.filePathEdit)
         path_row.addWidget(self.browseButton)
         path_row.addWidget(self.loadButton)
+        path_row.addWidget(self.cancelLoadButton)
         layout.addLayout(path_row)
 
         self.previewLabel = QLabel("Preview", dialog)

--- a/app/model/scraper/document_scraper.py
+++ b/app/model/scraper/document_scraper.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import importlib.util
 from pathlib import Path
 
@@ -13,6 +13,7 @@ class DocumentRow:
     title: str
     primary_text: str
     secondary_text: str = ""
+    metadata: dict = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -195,6 +196,7 @@ class DocumentScraper:
             "secondary_text": row.secondary_text,
             "source_path": str(path),
             "source_type": path.suffix.lower().lstrip("."),
+            "metadata": dict(row.metadata),
         }
 
     def _has_content(self, row):
@@ -208,6 +210,137 @@ class DocumentScraper:
         blocks = [block.strip() for block in normalized.split("\n\n")]
         return [block for block in blocks if block]
 
+    def _heading_level(self, style_name):
+        normalized_style = (style_name or "").strip().lower()
+        if not normalized_style.startswith("heading"):
+            return None
+
+        level_text = normalized_style.replace("heading", "").strip()
+        return int(level_text) if level_text.isdigit() else 1
+
+    def _table_to_rows(self, table_rows, start_item_number, table_index):
+        extracted_rows = []
+        raw_rows = []
+        for row in table_rows:
+            if hasattr(row, "cells"):
+                raw_rows.append([cell.text.strip() for cell in row.cells])
+            else:
+                raw_rows.append([str(cell).strip() for cell in row])
+        raw_rows = [row for row in raw_rows if any(cell for cell in row)]
+        if not raw_rows:
+            return extracted_rows
+
+        headers = raw_rows[0]
+        data_rows = raw_rows[1:] if len(raw_rows) > 1 else raw_rows
+        for row_offset, cells in enumerate(data_rows, start=1):
+            if len(headers) == len(cells) and len(raw_rows) > 1:
+                values = [
+                    f"{header or f'Column {index + 1}'}: {value}"
+                    for index, (header, value) in enumerate(zip(headers, cells))
+                    if value
+                ]
+            else:
+                values = [
+                    f"Column {index + 1}: {value}"
+                    for index, value in enumerate(cells)
+                    if value
+                ]
+
+            if not values:
+                continue
+
+            extracted_rows.append(
+                DocumentRow(
+                    start_item_number + len(extracted_rows),
+                    f"Table {table_index} Row {row_offset}",
+                    "\n".join(values),
+                    f"Table: {table_index}",
+                    {
+                        "kind": "table_row",
+                        "table_number": table_index,
+                        "row_number": row_offset,
+                        "headers": headers if len(raw_rows) > 1 else [],
+                    },
+                )
+            )
+        return extracted_rows
+
+    def _html_to_rows(self, soup, document_title, row_kind):
+        rows = []
+        current_heading = None
+        current_level = None
+        current_chunks = []
+        table_index = 1
+
+        def flush_section():
+            nonlocal current_heading, current_level, current_chunks
+            if not current_chunks:
+                return
+
+            item_number = len(rows) + 1
+            rows.append(
+                DocumentRow(
+                    item_number,
+                    current_heading or f"{document_title} Section {item_number}",
+                    "\n\n".join(current_chunks),
+                    metadata={
+                        "kind": row_kind,
+                        "heading": current_heading,
+                        "heading_level": current_level,
+                    },
+                )
+            )
+            current_heading = None
+            current_level = None
+            current_chunks = []
+
+        body = soup.body or soup
+        for element in body.find_all(
+            ["h1", "h2", "h3", "h4", "h5", "h6", "p", "li", "table"]
+        ):
+            text = element.get_text(" ", strip=True)
+            if not text:
+                continue
+
+            tag_name = element.name.lower()
+            if tag_name.startswith("h") and tag_name[1:].isdigit():
+                flush_section()
+                current_heading = text
+                current_level = int(tag_name[1:])
+                current_chunks = [text]
+            elif tag_name == "li":
+                current_chunks.append(f"- {text}")
+            elif tag_name == "table":
+                flush_section()
+                table_rows = [
+                    [cell.get_text(" ", strip=True) for cell in row.find_all(["th", "td"])]
+                    for row in element.find_all("tr")
+                ]
+                rows.extend(
+                    self._table_to_rows(
+                        table_rows,
+                        len(rows) + 1,
+                        table_index,
+                    )
+                )
+                table_index += 1
+            else:
+                current_chunks.append(text)
+
+        flush_section()
+        if rows:
+            return rows
+
+        text = body.get_text(" ", strip=True)
+        return [
+            DocumentRow(
+                1,
+                f"{document_title} Section 1",
+                text,
+                metadata={"kind": row_kind},
+            )
+        ] if text else []
+
     def _scrape_txt(self, path):
         text = path.read_text(encoding="utf-8")
         blocks = self._split_blocks(text) or [text.strip()]
@@ -219,17 +352,83 @@ class DocumentScraper:
 
     def _scrape_docx(self, path):
         from docx import Document
+        from docx.oxml.table import CT_Tbl
+        from docx.oxml.text.paragraph import CT_P
+        from docx.table import Table
+        from docx.text.paragraph import Paragraph
 
         document = Document(path)
-        paragraphs = [
-            paragraph.text.strip()
-            for paragraph in document.paragraphs
-            if paragraph.text.strip()
-        ]
-        return [
-            DocumentRow(index, f"Paragraph {index}", paragraph)
-            for index, paragraph in enumerate(paragraphs, start=1)
-        ]
+        rows = []
+        item_number = 1
+        section_title = None
+        section_level = None
+        section_chunks = []
+        paragraph_index = 1
+        table_index = 1
+
+        def flush_section():
+            nonlocal item_number, section_title, section_level, section_chunks
+            if not section_chunks:
+                return
+
+            rows.append(
+                DocumentRow(
+                    item_number,
+                    section_title or f"Document Section {item_number}",
+                    "\n\n".join(section_chunks),
+                    metadata={
+                        "kind": "section",
+                        "heading_level": section_level,
+                    },
+                )
+            )
+            item_number += 1
+            section_title = None
+            section_level = None
+            section_chunks = []
+
+        for child in document.element.body.iterchildren():
+            if isinstance(child, CT_P):
+                block = Paragraph(child, document)
+                text = block.text.strip()
+                if not text:
+                    continue
+
+                style_name = block.style.name if block.style else ""
+                heading_level = self._heading_level(style_name)
+                if heading_level is not None:
+                    flush_section()
+                    section_title = text
+                    section_level = heading_level
+                    section_chunks = [text]
+                    continue
+
+                if section_title:
+                    section_chunks.append(text)
+                else:
+                    rows.append(
+                        DocumentRow(
+                            item_number,
+                            f"Paragraph {paragraph_index}",
+                            text,
+                            metadata={
+                                "kind": "paragraph",
+                                "paragraph_index": paragraph_index,
+                            },
+                        )
+                    )
+                    item_number += 1
+                    paragraph_index += 1
+            elif isinstance(child, CT_Tbl):
+                flush_section()
+                table = Table(child, document)
+                table_rows = self._table_to_rows(table.rows, item_number, table_index)
+                rows.extend(table_rows)
+                item_number += len(table_rows)
+                table_index += 1
+
+        flush_section()
+        return rows
 
     def _scrape_pdf(self, path):
         from pypdf import PdfReader
@@ -241,7 +440,18 @@ class DocumentScraper:
             page_text = (page.extract_text() or "").strip()
             if not page_text:
                 needs_ocr = True
-            rows.append(DocumentRow(index, f"Page {index}", page_text))
+            rows.append(
+                DocumentRow(
+                    index,
+                    f"Page {index}",
+                    page_text,
+                    metadata={
+                        "kind": "page",
+                        "page_number": index,
+                        "extraction": "text-layer" if page_text else "ocr-needed",
+                    },
+                )
+            )
 
         if needs_ocr:
             ocr_rows = self._perform_ocr_on_pdf(path)
@@ -258,6 +468,11 @@ class DocumentScraper:
                                 row.title,
                                 ocr_row.primary_text,
                                 ocr_row.secondary_text,
+                                {
+                                    "kind": "page",
+                                    "page_number": row.item_number,
+                                    "extraction": "ocr",
+                                },
                             )
                         )
                     else:
@@ -271,18 +486,7 @@ class DocumentScraper:
         html = path.read_text(encoding="utf-8")
         soup = BeautifulSoup(html, "html.parser")
         title = soup.title.get_text(strip=True) if soup.title else path.stem
-        paragraphs = [
-            element.get_text(" ", strip=True)
-            for element in soup.find_all(["h1", "h2", "h3", "p", "li"])
-            if element.get_text(" ", strip=True)
-        ]
-        if not paragraphs:
-            paragraphs = [soup.get_text(" ", strip=True)]
-        return [
-            DocumentRow(index, f"{title} Section {index}", paragraph)
-            for index, paragraph in enumerate(paragraphs, start=1)
-            if paragraph
-        ]
+        return self._html_to_rows(soup, title, "html_section")
 
     def _scrape_rtf(self, path):
         from striprtf.striprtf import rtf_to_text
@@ -309,11 +513,32 @@ class DocumentScraper:
             if hasattr(item, "is_chapter") and not item.is_chapter():
                 continue
             soup = BeautifulSoup(item.get_content(), "html.parser")
-            title = soup.title.get_text(strip=True) if soup.title else f"Chapter {item_number}"
-            text = soup.get_text(" ", strip=True)
+            title = (
+                soup.title.get_text(strip=True)
+                if soup.title
+                else getattr(item, "title", "") or f"Chapter {item_number}"
+            )
+            body = soup.body or soup
+            text_parts = [
+                element.get_text(" ", strip=True)
+                for element in body.find_all(["h1", "h2", "h3", "p", "li"])
+                if element.get_text(" ", strip=True)
+            ]
+            text = "\n\n".join(text_parts) or soup.get_text(" ", strip=True)
             if not text:
                 continue
-            rows.append(DocumentRow(item_number, title, text))
+            rows.append(
+                DocumentRow(
+                    item_number,
+                    title,
+                    text,
+                    metadata={
+                        "kind": "chapter",
+                        "chapter_number": item_number,
+                        "file_name": item.get_name(),
+                    },
+                )
+            )
             item_number += 1
         return rows
 
@@ -341,7 +566,14 @@ class DocumentScraper:
                     DocumentRow(
                         item_number,
                         f"{sheet_name} Row {row_index + 1}",
-                        " | ".join(values),
+                        "\n".join(values),
+                        f"Sheet: {sheet_name}\nColumns: {', '.join(map(str, cleaned_frame.columns))}",
+                        {
+                            "kind": "sheet_row",
+                            "sheet_name": str(sheet_name),
+                            "row_number": int(row_index + 1),
+                            "columns": [str(column) for column in cleaned_frame.columns],
+                        },
                     )
                 )
                 item_number += 1
@@ -366,13 +598,28 @@ class DocumentScraper:
                     f"Slide {index}",
                     " ".join(slide_text).strip(),
                     notes_text,
+                    {
+                        "kind": "slide",
+                        "slide_number": index,
+                        "has_notes": bool(notes_text),
+                    },
                 )
             )
         return rows
 
     def _scrape_image(self, path):
         ocr_text = self._perform_ocr_on_image(path)
-        return [DocumentRow(1, path.stem or "Image 1", ocr_text)]
+        return [
+            DocumentRow(
+                1,
+                path.stem or "Image 1",
+                ocr_text,
+                metadata={
+                    "kind": "image",
+                    "extraction": "ocr",
+                },
+            )
+        ]
 
     def _perform_ocr_on_pdf(self, path):
         try:

--- a/docs/gui.rst
+++ b/docs/gui.rst
@@ -53,10 +53,13 @@ It provides:
 - item/title column
 - primary text column
 - secondary text column
+- heading-aware rows for structured documents
+- table, spreadsheet, and slide metadata that preserves source context
 - multi-row selection
 - content-mode selection
 - import of selected rows into the main editor
 - batch export of selected rows to one audio file per item
+- cancel controls for active document-load and batch-export work
 
 Currently supported file types include:
 
@@ -86,6 +89,8 @@ Examples:
 - playback volume controls are disabled when multimedia playback support is not
   available
 - the preview button text changes when only file generation is possible
+- long-running document-load and batch-export work exposes cancel controls while
+  the worker is active
 
 Recent Audio History
 --------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "texttospeechpython"
-version = "0.1.2"
+version = "0.1.3"
 description = "PyQt desktop app for experimenting with Azure text-to-speech and SSML workflows."
 readme = "README.md"
 authors = [{ name = "Thaddeus Thomas" }]

--- a/tests/test_background_workers.py
+++ b/tests/test_background_workers.py
@@ -23,7 +23,7 @@ sys.modules.setdefault("azure", azure_module)
 sys.modules.setdefault("azure.cognitiveservices", cognitiveservices_module)
 sys.modules.setdefault("azure.cognitiveservices.speech", speech_module)
 
-from app.controller.background_workers import BatchExportWorker
+from app.controller.background_workers import BatchExportWorker, DocumentParseWorker
 from app.model.app_settings import AppSettings
 
 
@@ -37,6 +37,22 @@ class FakeTTSProcessor:
 
 
 class BackgroundWorkerTests(unittest.TestCase):
+    def test_document_parse_worker_can_cancel_before_parsing(self):
+        cancelled = []
+        finished = []
+        failed = []
+        worker = DocumentParseWorker("does-not-need-to-exist.txt")
+        worker.cancelled.connect(lambda: cancelled.append(True))
+        worker.finished.connect(finished.append)
+        worker.failed.connect(failed.append)
+
+        worker.request_cancel()
+        worker.run()
+
+        self.assertEqual(cancelled, [True])
+        self.assertFalse(finished)
+        self.assertFalse(failed)
+
     def test_batch_export_worker_writes_files_and_reports_progress(self):
         temp_dir = Path("data/dynamic/tmp/batch_worker_test")
         shutil.rmtree(temp_dir, ignore_errors=True)
@@ -88,6 +104,63 @@ class BackgroundWorkerTests(unittest.TestCase):
                 b"Unique batch worker sample text",
                 exported_file.read_bytes(),
             )
+        finally:
+            shutil.rmtree(temp_dir, ignore_errors=True)
+
+    def test_batch_export_worker_can_cancel_between_rows(self):
+        temp_dir = Path("data/dynamic/tmp/batch_worker_cancel_test")
+        shutil.rmtree(temp_dir, ignore_errors=True)
+        temp_dir.mkdir(parents=True, exist_ok=True)
+        rows = [
+            {
+                "item_number": 1,
+                "title": "First",
+                "content_mode": "combine",
+                "resolved_text": "First cancel sample.",
+            },
+            {
+                "item_number": 2,
+                "title": "Second",
+                "content_mode": "combine",
+                "resolved_text": "Second cancel sample.",
+            },
+        ]
+        finished = []
+        cancelled = []
+        progress = []
+
+        try:
+            worker = BatchExportWorker(
+                rows=rows,
+                output_dir=temp_dir,
+                settings=AppSettings(auto_clean_text=False),
+                azure_key="fake-key",
+                azure_region="fake-region",
+            )
+            worker.finished.connect(finished.append)
+            worker.cancelled.connect(cancelled.append)
+
+            def cancel_after_first_file(completed, total, path):
+                progress.append((completed, total, Path(path).name))
+                worker.request_cancel()
+
+            worker.progress.connect(cancel_after_first_file)
+
+            with patch(
+                "app.controller.background_workers.create_tts_processor",
+                lambda azure_key, azure_region: FakeTTSProcessor(
+                    azure_key,
+                    azure_region,
+                ),
+            ):
+                worker.run()
+
+            self.assertFalse(finished)
+            self.assertEqual(progress, [(1, 2, "item_01_first_combine.mp3")])
+            self.assertEqual(len(cancelled), 1)
+            self.assertEqual(len(cancelled[0]), 1)
+            self.assertTrue((temp_dir / "item_01_first_combine.mp3").exists())
+            self.assertFalse((temp_dir / "item_02_second_combine.mp3").exists())
         finally:
             shutil.rmtree(temp_dir, ignore_errors=True)
 

--- a/tests/test_document_scraper.py
+++ b/tests/test_document_scraper.py
@@ -86,6 +86,7 @@ class DocumentScraperTests(unittest.TestCase):
         self.assertEqual(rows[0]["primary_text"], "First block.")
         self.assertEqual(rows[1]["primary_text"], "Second block.")
         self.assertEqual(rows[0]["source_type"], "txt")
+        self.assertEqual(rows[0]["metadata"], {})
 
     def test_dependency_status_reports_missing_advertised_parser_packages(self):
         missing_modules = {"ebooklib", "striprtf", "xlrd"}
@@ -145,9 +146,32 @@ class DocumentScraperTests(unittest.TestCase):
 
         rows = self.scraper.scrape_file(html_path)
 
-        self.assertGreaterEqual(len(rows), 2)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["title"], "Heading")
         self.assertEqual(rows[0]["source_type"], "html")
         self.assertIn("Heading", rows[0]["primary_text"])
+        self.assertIn("Paragraph two.", rows[0]["primary_text"])
+        self.assertEqual(rows[0]["metadata"]["kind"], "html_section")
+        self.assertEqual(rows[0]["metadata"]["heading_level"], 1)
+
+    def test_scrape_html_preserves_table_rows(self):
+        html_path = self.temp_dir / "table.html"
+        html_path.write_text(
+            (
+                "<html><body>"
+                "<table><tr><th>Step</th><th>Status</th></tr>"
+                "<tr><td>Import</td><td>Ready</td></tr></table>"
+                "</body></html>"
+            ),
+            encoding="utf-8",
+        )
+
+        rows = self.scraper.scrape_file(html_path)
+
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["title"], "Table 1 Row 1")
+        self.assertIn("Step: Import", rows[0]["primary_text"])
+        self.assertEqual(rows[0]["metadata"]["kind"], "table_row")
 
     def test_scrape_docx_extracts_paragraphs(self):
         docx_path = self.temp_dir / "sample.docx"
@@ -161,6 +185,29 @@ class DocumentScraperTests(unittest.TestCase):
         self.assertEqual(len(rows), 2)
         self.assertEqual(rows[0]["title"], "Paragraph 1")
         self.assertEqual(rows[1]["primary_text"], "Second paragraph.")
+        self.assertEqual(rows[0]["metadata"]["kind"], "paragraph")
+
+    def test_scrape_docx_preserves_headings_and_tables(self):
+        docx_path = self.temp_dir / "structured.docx"
+        document = Document()
+        document.add_heading("Launch Plan", level=1)
+        document.add_paragraph("Prepare the narration script.")
+        table = document.add_table(rows=2, cols=2)
+        table.cell(0, 0).text = "Task"
+        table.cell(0, 1).text = "Owner"
+        table.cell(1, 0).text = "Record intro"
+        table.cell(1, 1).text = "Narrator"
+        document.save(docx_path)
+
+        rows = self.scraper.scrape_file(docx_path)
+
+        self.assertEqual(rows[0]["title"], "Launch Plan")
+        self.assertIn("Prepare the narration script.", rows[0]["primary_text"])
+        self.assertEqual(rows[0]["metadata"]["kind"], "section")
+        self.assertEqual(rows[0]["metadata"]["heading_level"], 1)
+        self.assertEqual(rows[1]["title"], "Table 1 Row 1")
+        self.assertIn("Task: Record intro", rows[1]["primary_text"])
+        self.assertEqual(rows[1]["metadata"]["kind"], "table_row")
 
     def test_scrape_pdf_extracts_page_text(self):
         pdf_path = self.temp_dir / "sample.pdf"
@@ -171,6 +218,8 @@ class DocumentScraperTests(unittest.TestCase):
         self.assertEqual(len(rows), 1)
         self.assertEqual(rows[0]["title"], "Page 1")
         self.assertIn("Hello PDF", rows[0]["primary_text"])
+        self.assertEqual(rows[0]["metadata"]["kind"], "page")
+        self.assertEqual(rows[0]["metadata"]["extraction"], "text-layer")
 
     @unittest.skipUnless(HAS_STRIPRTF, "striprtf is not installed")
     def test_scrape_rtf_extracts_text(self):
@@ -209,6 +258,8 @@ class DocumentScraperTests(unittest.TestCase):
         self.assertEqual(len(rows), 1)
         self.assertEqual(rows[0]["title"], "Chapter 1")
         self.assertIn("EPUB body text.", rows[0]["primary_text"])
+        self.assertEqual(rows[0]["metadata"]["kind"], "chapter")
+        self.assertEqual(rows[0]["metadata"]["chapter_number"], 1)
 
     def test_scrape_csv_extracts_rows(self):
         csv_path = self.temp_dir / "sample.csv"
@@ -221,6 +272,9 @@ class DocumentScraperTests(unittest.TestCase):
         self.assertEqual(len(rows), 2)
         self.assertEqual(rows[0]["title"], "Sheet1 Row 1")
         self.assertIn("Name: Alice", rows[0]["primary_text"])
+        self.assertIn("Columns: Name, Role", rows[0]["secondary_text"])
+        self.assertEqual(rows[0]["metadata"]["kind"], "sheet_row")
+        self.assertEqual(rows[0]["metadata"]["sheet_name"], "Sheet1")
 
     @unittest.skipUnless(HAS_OPENPYXL, "openpyxl is not installed")
     def test_scrape_xlsx_extracts_rows(self):
@@ -237,6 +291,7 @@ class DocumentScraperTests(unittest.TestCase):
         self.assertEqual(len(rows), 1)
         self.assertEqual(rows[0]["title"], "Outline Row 1")
         self.assertIn("Chapter: Intro", rows[0]["primary_text"])
+        self.assertEqual(rows[0]["metadata"]["columns"], ["Chapter", "Pages"])
 
     def test_scrape_pptx_extracts_slide_text_and_notes(self):
         pptx_path = self.temp_dir / "sample.pptx"
@@ -254,6 +309,8 @@ class DocumentScraperTests(unittest.TestCase):
         self.assertEqual(rows[0]["title"], "Slide 1")
         self.assertIn("Slide Heading", rows[0]["primary_text"])
         self.assertIn("Speaker notes.", rows[0]["secondary_text"])
+        self.assertEqual(rows[0]["metadata"]["kind"], "slide")
+        self.assertTrue(rows[0]["metadata"]["has_notes"])
 
     def test_scrape_image_uses_ocr_path(self):
         image_path = self.temp_dir / "sample.png"
@@ -274,6 +331,7 @@ class DocumentScraperTests(unittest.TestCase):
         self.assertEqual(rows[0]["title"], "sample")
         self.assertEqual(rows[0]["primary_text"], "Scanned image text")
         self.assertEqual(rows[0]["source_type"], "png")
+        self.assertEqual(rows[0]["metadata"]["extraction"], "ocr")
 
     def test_scrape_pdf_falls_back_to_ocr_when_text_layer_is_missing(self):
         pdf_path = self.temp_dir / "scanned.pdf"
@@ -293,6 +351,7 @@ class DocumentScraperTests(unittest.TestCase):
         self.assertEqual(len(rows), 1)
         self.assertEqual(rows[0]["title"], "Page 1")
         self.assertEqual(rows[0]["primary_text"], "OCR page text")
+        self.assertEqual(rows[0]["metadata"]["extraction"], "ocr")
 
 
 if __name__ == "__main__":

--- a/tests/test_main_controller_ssml.py
+++ b/tests/test_main_controller_ssml.py
@@ -118,6 +118,8 @@ class ActionStateViewStub:
         self.generateButton = ToggleStub()
         self.actionExportAudio = ToggleStub()
         self.stopButton = ToggleStub()
+        self.cancelTaskButton = ToggleStub()
+        self.openSecondWindowButton = ToggleStub()
         self.playbackVolumeSlider = ToggleStub()
         self.actionHintLabel = LabelStub()
 
@@ -138,6 +140,23 @@ class MainControllerActionStateTests(unittest.TestCase):
         self.assertFalse(controller.view.generateButton.enabled)
         self.assertFalse(controller.view.actionExportAudio.enabled)
         self.assertIn("Type or import text", controller.view.actionHintLabel.text)
+
+    def test_refresh_action_states_enables_cancel_during_background_work(self):
+        controller = MainController.__new__(MainController)
+        controller.settings = AppSettings()
+        controller.view = ActionStateViewStub("Hello world")
+        controller.media_player = object()
+        controller.audio_output = object()
+        controller.preview_audio_path = None
+        controller.batch_export_active = True
+        controller.document_parse_thread = None
+
+        controller._refresh_action_states()
+
+        self.assertTrue(controller.view.cancelTaskButton.enabled)
+        self.assertFalse(controller.view.generateButton.enabled)
+        self.assertFalse(controller.view.openSecondWindowButton.enabled)
+        self.assertIn("Cancel Task", controller.view.actionHintLabel.text)
 
     def test_refresh_action_states_relabels_preview_when_multimedia_unavailable(self):
         controller = MainController.__new__(MainController)


### PR DESCRIPTION
## Summary

This PR deepens the document import pipeline so extracted content preserves more structure and adds cancellation support for long-running import/export work.

## Changes

- Added structured metadata to imported document rows.
- Improved DOCX scraping to preserve heading-led sections and table rows.
- Improved HTML scraping to group content by headings and preserve table rows.
- Improved EPUB scraping to retain chapter metadata.
- Improved spreadsheet scraping to preserve sheet, row, and column context.
- Added page/slide/OCR metadata for PDF, PPTX, and image imports.
- Added a main-window `Cancel Task` action for active document loading and batch export jobs.
- Added an import-dialog `Cancel Load` action for active document parsing.
- Added cooperative cancellation flags to background workers.
- Added partial batch export reporting when a job is canceled.
- Updated docs to mention richer import structure and cancel controls.
- Added tests for structured scraping metadata and worker cancellation behavior.

## Verification

- `poetry run python -m unittest discover -s tests`
- `poetry check`

## Issues

Closes #46  
Closes #53
