### PR TITLE
Improve document import UX with format-aware modes, open-any-source import, and actionable audio history

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,11 @@ The current application supports:
   playback volume, and advanced SSML controls
 - document import for `.txt`, `.docx`, `.pdf`, `.html`, `.htm`, `.rtf`,
   `.epub`, `.xlsx`, `.xls`, `.csv`, and `.pptx`
+- direct import of web URLs and pasted raw HTML through the same document
+  extraction path
 - selective import of extracted document sections into the main editor
 - batch export of selected imported rows to one audio file per item
-- recent audio history in the main window
+- actionable recent audio history in the main window
 
 ## Requirements
 
@@ -88,11 +90,12 @@ GUI settings take precedence over `.env` when both are present.
 
 ## Main Workflow
 
-1. Paste text into the editor, or import content from `Import Document`.
+1. Paste text into the editor, open a local document, open a URL, import raw
+   HTML, or use `Import Document` for row-based selection.
 2. Open `Tools > Settings` to configure Azure, voice, output directory, and SSML options.
 3. Review the generated SSML preview.
 4. Use `Generate & Play` for a temporary preview file or `Generate File` to export an `.mp3`.
-5. Review recent generated files in the `Recent Audio` panel.
+5. Review, replay, copy, reopen, or restore previous work from the `Recent Audio` panel.
 
 ## Advanced SSML Controls
 
@@ -114,18 +117,21 @@ These controls are applied to both the SSML preview and generated audio.
 - a row-based preview of extracted document sections
 - heading-aware rows for DOCX, HTML, and EPUB content where available
 - table and spreadsheet rows that keep sheet, column, and table context
+- format-aware column labels and import modes, such as slide notes, page text,
+  chapter text, OCR text, or spreadsheet row context
 - multi-row selection
-- content modes:
-  - `Prefer Secondary Text`
-  - `Secondary Text Only`
-  - `Primary Text Only`
-  - `Combine Primary and Secondary Text`
+- content modes that adapt to the loaded format, such as page text, slide
+  notes, chapter text, OCR text, or spreadsheet row context
 
 From that dialog you can:
 
 - import the selected rows into the main editor
 - batch export the selected rows to one `.mp3` per item
 - cancel active document-load or batch-export work without closing the app
+
+The main window also supports quick source import from `File > Open Document`,
+`File > Open URL`, and `File > Import Raw HTML`. URL and raw HTML imports are
+parsed as structured HTML sections before being placed in the editor.
 
 ## Logging
 
@@ -140,6 +146,20 @@ Log timestamps use:
 ```text
 YYYYMMDDHHmmss
 ```
+
+## Recent Audio History
+
+The `Recent Audio` panel keeps the latest generated files and supports workflow
+actions:
+
+- double-click a history item to replay it
+- right-click to open the containing folder
+- right-click to copy the generated audio path
+- right-click to restore the source text and voice/settings snapshot used for
+  that generation
+
+New history entries include the editor text and relevant synthesis settings so
+recent exports can be reused without manually reconstructing the previous setup.
 
 ## Runtime Data
 
@@ -163,12 +183,12 @@ The app writes runtime artifacts under `data/dynamic/`, including:
 
 ## Project Layout
 
-- [app/main.py](D:/Projects/TextToSpeechPython/app/main.py): application entrypoint
-- [app/gui](D:/Projects/TextToSpeechPython/app/gui): in-repo Qt UI modules and dialogs
-- [app/controller](D:/Projects/TextToSpeechPython/app/controller): GUI orchestration and workflow logic
-- [app/model](D:/Projects/TextToSpeechPython/app/model): settings, Azure wrappers, SSML helpers, and scrapers
-- [docs](D:/Projects/TextToSpeechPython/docs): supporting documentation
-- [tests](D:/Projects/TextToSpeechPython/tests): focused regression tests
+- [app/main.py](app/main.py): application entrypoint
+- [app/gui](app/gui): in-repo Qt UI modules and dialogs
+- [app/controller](app/controller): GUI orchestration and workflow logic
+- [app/model](app/model): settings, Azure wrappers, SSML helpers, and scrapers
+- [docs](docs): supporting documentation
+- [tests](tests): focused regression tests
 
 ## Verification
 

--- a/app/controller/background_workers.py
+++ b/app/controller/background_workers.py
@@ -64,15 +64,16 @@ def build_ssml_document(text, settings, cleaner=None):
 
 
 class DocumentParseWorker(QObject):
-    """Parse a document away from the UI thread."""
+    """Parse a document or source payload away from the UI thread."""
 
     finished = pyqtSignal(object)
     failed = pyqtSignal(str)
     cancelled = pyqtSignal()
 
-    def __init__(self, file_path):
+    def __init__(self, source, source_kind="file"):
         super().__init__()
-        self.file_path = file_path
+        self.source = source
+        self.source_kind = source_kind
         self._cancel_requested = False
 
     def request_cancel(self):
@@ -84,9 +85,21 @@ class DocumentParseWorker(QObject):
             return
 
         try:
-            rows = DocumentScraper().scrape_file(self.file_path)
+            scraper = DocumentScraper()
+            if self.source_kind == "file":
+                rows = scraper.scrape_file(self.source)
+            elif self.source_kind == "url":
+                rows = scraper.scrape_url(self.source)
+            elif self.source_kind == "html":
+                rows = scraper.scrape_html_text(self.source)
+            else:
+                raise ValueError(f"Unsupported document source: {self.source_kind}")
         except Exception as error:
-            logger.exception("Document parsing failed for {}: {}", self.file_path, error)
+            logger.exception(
+                "Document parsing failed for {} source: {}",
+                self.source_kind,
+                error,
+            )
             self.failed.emit(str(error))
             return
 
@@ -152,7 +165,9 @@ class BatchExportWorker(QObject):
                     self.cancelled.emit(exported_files)
                     return
 
-                mode_name = sanitize_batch_name(row.get("content_mode", "prefer_notes"))
+                mode_name = sanitize_batch_name(
+                    row.get("content_mode", "prefer_secondary")
+                )
                 title_name = sanitize_batch_name(
                     row.get("title", f"item_{row.get('item_number', 0)}")
                 )

--- a/app/controller/main_controller.py
+++ b/app/controller/main_controller.py
@@ -4,8 +4,16 @@ import tempfile
 from datetime import datetime
 from xml.sax.saxutils import escape
 
-from PyQt6.QtCore import QObject, QThread, QUrl
-from PyQt6.QtWidgets import QFileDialog, QMessageBox
+from PyQt6.QtCore import QObject, Qt, QThread, QUrl
+from PyQt6.QtGui import QDesktopServices
+from PyQt6.QtWidgets import (
+    QApplication,
+    QFileDialog,
+    QInputDialog,
+    QListWidgetItem,
+    QMenu,
+    QMessageBox,
+)
 
 try:
     from PyQt6.QtMultimedia import QAudioOutput, QMediaPlayer
@@ -36,6 +44,18 @@ class MainController(QObject):
     SETTINGS_PATH = Path("data/dynamic/app_settings.json")
     AUDIO_HISTORY_PATH = Path("data/dynamic/audio_history.json")
     MAX_HISTORY_ITEMS = 10
+    HISTORY_SETTINGS_FIELDS = (
+        "voice",
+        "speaking_rate",
+        "synthesis_volume",
+        "emphasis_level",
+        "pitch",
+        "pitch_range",
+        "pause_duration",
+        "pause_position",
+        "auto_clean_text",
+        "output_dir",
+    )
 
     def __init__(self, view):
         super().__init__()
@@ -50,6 +70,7 @@ class MainController(QObject):
         self.second_controller = None
         self.latest_audio_path = None
         self.preview_audio_path = None
+        self.playing_history_audio_path = None
         self.audio_output = None
         self.media_player = None
         self.document_parse_thread = None
@@ -90,6 +111,8 @@ class MainController(QObject):
             self.update_playback_volume
         )
         self.view.actionOpenText.triggered.connect(self.open_document_file)
+        self.view.actionOpenUrl.triggered.connect(self.open_url_source)
+        self.view.actionOpenRawHtml.triggered.connect(self.open_raw_html_source)
         self.view.actionSaveText.triggered.connect(self.save_text_file)
         self.view.actionExportAudio.triggered.connect(self.export_audio_file)
         self.view.actionExit.triggered.connect(self.view.close)
@@ -97,6 +120,12 @@ class MainController(QObject):
         self.view.actionOpenScraper.triggered.connect(self.open_second_window)
         self.view.actionAbout.triggered.connect(self.show_about)
         self.view.textEdit.textChanged.connect(self._handle_editor_text_changed)
+        self.view.historyList.itemDoubleClicked.connect(
+            self.play_selected_history_audio
+        )
+        self.view.historyList.customContextMenuRequested.connect(
+            self.show_history_context_menu
+        )
 
     def _sanitize_batch_name(self, value):
         return sanitize_batch_name(value)
@@ -148,7 +177,10 @@ class MainController(QObject):
         multimedia_available = (
             self.media_player is not None and self.audio_output is not None
         )
-        has_preview_audio = bool(self.preview_audio_path)
+        has_preview_audio = bool(
+            self.preview_audio_path
+            or self.__dict__.get("playing_history_audio_path")
+        )
         background_work_active = self.__dict__.get("batch_export_active", False) or (
             self.__dict__.get("document_parse_thread") is not None
         )
@@ -253,6 +285,8 @@ class MainController(QObject):
                     "voice": str(entry.get("voice", self.settings.voice)),
                     "generated_at": str(entry.get("generated_at", "")),
                     "source": str(entry.get("source", "export")),
+                    "source_text": str(entry.get("source_text", "")),
+                    "settings": dict(entry.get("settings") or {}),
                 }
             )
         return cleaned_history[: self.MAX_HISTORY_ITEMS]
@@ -278,16 +312,32 @@ class MainController(QObject):
             return
 
         for entry in self.audio_history:
-            self.view.historyList.addItem(self._format_history_entry(entry))
+            item = QListWidgetItem(self._format_history_entry(entry))
+            item.setToolTip(
+                "Double-click to play. Right-click for more history actions."
+            )
+            item.setData(Qt.ItemDataRole.UserRole, entry)
+            self.view.historyList.addItem(item)
 
-    def _record_audio_history(self, file_path, source):
+    def _history_settings_snapshot(self):
+        return {
+            field_name: getattr(self.settings, field_name)
+            for field_name in self.HISTORY_SETTINGS_FIELDS
+            if hasattr(self.settings, field_name)
+        }
+
+    def _record_audio_history(self, file_path, source, source_text=None):
         audio_path = Path(file_path)
+        if source_text is None and hasattr(self.view, "textEdit"):
+            source_text = self._current_editor_text()
         entry = {
             "filename": audio_path.name,
             "output_path": str(audio_path.resolve()),
             "voice": self.settings.voice,
             "generated_at": datetime.now().strftime("%Y%m%d%H%M%S"),
             "source": source,
+            "source_text": source_text or "",
+            "settings": self._history_settings_snapshot(),
         }
         self.audio_history = [
             item
@@ -302,6 +352,134 @@ class MainController(QObject):
         self._save_audio_history()
         self._refresh_history_panel()
         logger.info("Recorded {} audio history entry for {}", source, file_path)
+
+    def _selected_history_entry(self):
+        current_item = self.view.historyList.currentItem()
+        if current_item is not None:
+            entry = current_item.data(Qt.ItemDataRole.UserRole)
+            if isinstance(entry, dict):
+                return entry
+
+        current_row = self.view.historyList.currentRow()
+        if 0 <= current_row < len(self.audio_history):
+            return self.audio_history[current_row]
+        return None
+
+    def show_history_context_menu(self, position):
+        entry = self._selected_history_entry()
+        if not entry:
+            return
+
+        menu = QMenu(self.view)
+        play_action = menu.addAction("Play Audio")
+        open_folder_action = menu.addAction("Open Containing Folder")
+        copy_path_action = menu.addAction("Copy Audio Path")
+        restore_action = menu.addAction("Restore Text && Settings")
+
+        selected_action = menu.exec(self.view.historyList.mapToGlobal(position))
+        if selected_action == play_action:
+            self.play_selected_history_audio()
+        elif selected_action == open_folder_action:
+            self.open_selected_history_folder()
+        elif selected_action == copy_path_action:
+            self.copy_selected_history_path()
+        elif selected_action == restore_action:
+            self.restore_selected_history_context()
+
+    def play_selected_history_audio(self, *_args):
+        entry = self._selected_history_entry()
+        if not entry:
+            self.view.statusbar.showMessage("Select a history item first.")
+            return
+
+        audio_path = Path(entry.get("output_path", ""))
+        if not audio_path.exists():
+            QMessageBox.warning(
+                self.view,
+                "Audio Missing",
+                f"The saved audio file could not be found:\n\n{audio_path}",
+            )
+            self.view.statusbar.showMessage("History audio file is missing.")
+            return
+
+        self.latest_audio_path = str(audio_path)
+        if self.media_player is None or self.audio_output is None:
+            QMessageBox.information(
+                self.view,
+                "Playback Unavailable",
+                "Multimedia playback is unavailable in this environment.",
+            )
+            self.view.statusbar.showMessage(f"Selected history audio: {audio_path}")
+            return
+
+        self.playing_history_audio_path = str(audio_path)
+        self.media_player.setSource(QUrl.fromLocalFile(str(audio_path)))
+        self.media_player.play()
+        self._refresh_action_states()
+        self.view.statusbar.showMessage(f"Playing history audio: {audio_path.name}")
+        logger.info("Playing history audio from {}", audio_path)
+
+    def open_selected_history_folder(self):
+        entry = self._selected_history_entry()
+        if not entry:
+            self.view.statusbar.showMessage("Select a history item first.")
+            return
+
+        audio_path = Path(entry.get("output_path", ""))
+        folder_path = audio_path.parent
+        if not folder_path.exists():
+            QMessageBox.warning(
+                self.view,
+                "Folder Missing",
+                f"The containing folder could not be found:\n\n{folder_path}",
+            )
+            self.view.statusbar.showMessage("History folder is missing.")
+            return
+
+        QDesktopServices.openUrl(QUrl.fromLocalFile(str(folder_path)))
+        self.view.statusbar.showMessage(f"Opened folder: {folder_path}")
+        logger.info("Opened history audio folder {}", folder_path)
+
+    def copy_selected_history_path(self):
+        entry = self._selected_history_entry()
+        if not entry:
+            self.view.statusbar.showMessage("Select a history item first.")
+            return
+
+        audio_path = entry.get("output_path", "")
+        QApplication.clipboard().setText(audio_path)
+        self.view.statusbar.showMessage("Copied history audio path.")
+
+    def restore_selected_history_context(self):
+        entry = self._selected_history_entry()
+        if not entry:
+            self.view.statusbar.showMessage("Select a history item first.")
+            return
+
+        source_text = entry.get("source_text", "")
+        settings_snapshot = entry.get("settings") or {}
+        if not source_text and not settings_snapshot:
+            QMessageBox.information(
+                self.view,
+                "No History Context",
+                "This history item does not include reusable text or settings.",
+            )
+            self.view.statusbar.showMessage("No reusable history context available.")
+            return
+
+        for field_name in self.HISTORY_SETTINGS_FIELDS:
+            if field_name in settings_snapshot and hasattr(self.settings, field_name):
+                setattr(self.settings, field_name, settings_snapshot[field_name])
+
+        if source_text:
+            self.view.textEdit.setPlainText(source_text)
+
+        self.settings.save(self.SETTINGS_PATH)
+        self.tts_processor = None
+        self._refresh_ui_state()
+        self.update_ssml_preview()
+        self.view.statusbar.showMessage("Restored history text and settings.")
+        logger.info("Restored text/settings from audio history entry.")
 
     def _resolve_azure_credentials(self):
         if self.settings.azure_key and self.settings.azure_region:
@@ -330,15 +508,20 @@ class MainController(QObject):
 
     def _combine_document_rows(self, rows, content_mode="prefer_notes"):
         chunks = []
+        normalized_mode = {
+            "prefer_notes": "prefer_secondary",
+            "notes_only": "secondary_only",
+            "slide_text_only": "primary_only",
+        }.get(content_mode, content_mode)
         for row in rows:
             primary_text = (row.get("primary_text") or "").strip()
             secondary_text = (row.get("secondary_text") or "").strip()
 
-            if content_mode == "notes_only":
+            if normalized_mode == "secondary_only":
                 resolved_text = secondary_text
-            elif content_mode == "slide_text_only":
+            elif normalized_mode == "primary_only":
                 resolved_text = primary_text
-            elif content_mode == "combine":
+            elif normalized_mode == "combine":
                 resolved_parts = [part for part in (primary_text, secondary_text) if part]
                 resolved_text = "\n\n".join(resolved_parts)
             else:
@@ -455,6 +638,7 @@ class MainController(QObject):
             return
 
         self.media_player.setSource(QUrl.fromLocalFile(self.preview_audio_path))
+        self.playing_history_audio_path = None
         self.media_player.play()
         self.view.statusbar.showMessage("Playing generated audio.")
         logger.info("Playing generated audio from {}", self.preview_audio_path)
@@ -462,6 +646,7 @@ class MainController(QObject):
     def stop_audio(self):
         if self.media_player is not None:
             self.media_player.stop()
+        self.playing_history_audio_path = None
         self._refresh_action_states()
         self.view.statusbar.showMessage("Playback stopped.")
         logger.info("Playback stopped.")
@@ -685,14 +870,6 @@ class MainController(QObject):
         logger.info("Playback volume changed to {}%", value)
 
     def open_document_file(self):
-        if self.document_parse_thread is not None:
-            QMessageBox.information(
-                self.view,
-                "Document Loading",
-                "A document is already loading. Wait for it to finish before opening another one.",
-            )
-            return
-
         file_path, _ = QFileDialog.getOpenFileName(
             self.view,
             "Open Document",
@@ -702,9 +879,57 @@ class MainController(QObject):
         if not file_path:
             return
 
-        self.document_parse_path = file_path
+        self._start_document_parse(
+            source=file_path,
+            source_kind="file",
+            source_label=file_path,
+            status_message="Loading document in the background.",
+        )
+
+    def open_url_source(self):
+        url, accepted = QInputDialog.getText(
+            self.view,
+            "Open URL",
+            "Enter an http or https URL to import:",
+        )
+        if not accepted or not url.strip():
+            return
+
+        self._start_document_parse(
+            source=url.strip(),
+            source_kind="url",
+            source_label=url.strip(),
+            status_message="Loading URL in the background.",
+        )
+
+    def open_raw_html_source(self):
+        html, accepted = QInputDialog.getMultiLineText(
+            self.view,
+            "Import Raw HTML",
+            "Paste raw HTML to import:",
+        )
+        if not accepted or not html.strip():
+            return
+
+        self._start_document_parse(
+            source=html,
+            source_kind="html",
+            source_label="pasted raw HTML",
+            status_message="Loading raw HTML in the background.",
+        )
+
+    def _start_document_parse(self, source, source_kind, source_label, status_message):
+        if self.document_parse_thread is not None:
+            QMessageBox.information(
+                self.view,
+                "Document Loading",
+                "A document source is already loading. Wait for it to finish before opening another one.",
+            )
+            return
+
+        self.document_parse_path = source_label
         self.document_parse_thread = QThread(self.view)
-        self.document_parse_worker = DocumentParseWorker(file_path)
+        self.document_parse_worker = DocumentParseWorker(source, source_kind)
         self.document_parse_worker.moveToThread(self.document_parse_thread)
         self.document_parse_thread.started.connect(self.document_parse_worker.run)
         self.document_parse_worker.finished.connect(
@@ -731,9 +956,13 @@ class MainController(QObject):
         )
         self.document_parse_thread.finished.connect(self._clear_document_parse_worker)
         self._refresh_action_states()
-        self.view.statusbar.showMessage("Loading document in the background.")
+        self.view.statusbar.showMessage(status_message)
         self.document_parse_thread.start()
-        logger.info("Started background document load for {}", file_path)
+        logger.info(
+            "Started background {} document load for {}",
+            source_kind,
+            source_label,
+        )
 
     def _handle_document_parse_finished(self, rows):
         imported_text = self._combine_document_rows(rows)

--- a/app/controller/second_controller.py
+++ b/app/controller/second_controller.py
@@ -10,13 +10,141 @@ from loguru import logger
 
 
 class SecondController(QObject):
-    CONTENT_MODE_MAP = {
-        "Prefer Secondary Text": "prefer_notes",
-        "Secondary Text Only": "notes_only",
-        "Primary Text Only": "slide_text_only",
-        "Combine Slide Text and Notes": "combine",
-        "Combine Primary and Secondary Text": "combine",
+    CONTENT_MODES = {
+        "prefer_secondary": {
+            "primary_label": "Primary Text",
+            "secondary_label": "Secondary Text",
+            "label": "Prefer Secondary Text",
+        },
+        "secondary_only": {
+            "primary_label": "Primary Text",
+            "secondary_label": "Secondary Text",
+            "label": "Secondary Text Only",
+        },
+        "primary_only": {
+            "primary_label": "Primary Text",
+            "secondary_label": "Secondary Text",
+            "label": "Primary Text Only",
+        },
+        "combine": {
+            "primary_label": "Primary Text",
+            "secondary_label": "Secondary Text",
+            "label": "Combine Primary and Secondary Text",
+        },
     }
+    FORMAT_PROFILES = {
+        "pptx": {
+            "primary_label": "Slide Text",
+            "secondary_label": "Speaker Notes",
+            "modes": [
+                ("prefer_secondary", "Prefer Speaker Notes"),
+                ("secondary_only", "Speaker Notes Only"),
+                ("primary_only", "Slide Text Only"),
+                ("combine", "Combine Slide Text and Speaker Notes"),
+            ],
+            "help": "Select slides and choose whether to import slide text, speaker notes, or both:",
+        },
+        "pdf": {
+            "primary_label": "Page Text",
+            "secondary_label": "Page Context",
+            "modes": [
+                ("primary_only", "Page Text Only"),
+                ("combine", "Include Page Context"),
+            ],
+            "help": "Select pages and choose what page content to import or batch export:",
+        },
+        "docx": {
+            "primary_label": "Body / Section Text",
+            "secondary_label": "Structure Context",
+            "modes": [
+                ("primary_only", "Body Text Only"),
+                ("combine", "Include Structure Context"),
+            ],
+            "help": "Select document sections and choose what body content to import or batch export:",
+        },
+        "html": {
+            "primary_label": "Section Text",
+            "secondary_label": "HTML Context",
+            "modes": [
+                ("primary_only", "Section Text Only"),
+                ("combine", "Include HTML Context"),
+            ],
+            "help": "Select HTML sections and choose what content to import or batch export:",
+        },
+        "htm": {
+            "primary_label": "Section Text",
+            "secondary_label": "HTML Context",
+            "modes": [
+                ("primary_only", "Section Text Only"),
+                ("combine", "Include HTML Context"),
+            ],
+            "help": "Select HTML sections and choose what content to import or batch export:",
+        },
+        "epub": {
+            "primary_label": "Chapter Text",
+            "secondary_label": "Chapter Context",
+            "modes": [
+                ("primary_only", "Chapter Text Only"),
+                ("combine", "Include Chapter Context"),
+            ],
+            "help": "Select chapters and choose what chapter content to import or batch export:",
+        },
+        "csv": {
+            "primary_label": "Row Text",
+            "secondary_label": "Sheet / Column Context",
+            "modes": [
+                ("primary_only", "Row Text Only"),
+                ("combine", "Include Column Context"),
+            ],
+            "help": "Select rows and choose whether to include column context:",
+        },
+        "xlsx": {
+            "primary_label": "Row Text",
+            "secondary_label": "Sheet / Column Context",
+            "modes": [
+                ("primary_only", "Row Text Only"),
+                ("combine", "Include Sheet and Column Context"),
+            ],
+            "help": "Select spreadsheet rows and choose whether to include sheet/column context:",
+        },
+        "xls": {
+            "primary_label": "Row Text",
+            "secondary_label": "Sheet / Column Context",
+            "modes": [
+                ("primary_only", "Row Text Only"),
+                ("combine", "Include Sheet and Column Context"),
+            ],
+            "help": "Select spreadsheet rows and choose whether to include sheet/column context:",
+        },
+        "rtf": {
+            "primary_label": "Rich Text",
+            "secondary_label": "Context",
+            "modes": [
+                ("primary_only", "Rich Text Only"),
+                ("combine", "Include Context"),
+            ],
+            "help": "Select rich text blocks and choose what content to import or batch export:",
+        },
+        "txt": {
+            "primary_label": "Text Block",
+            "secondary_label": "Context",
+            "modes": [
+                ("primary_only", "Text Block Only"),
+                ("combine", "Include Context"),
+            ],
+            "help": "Select text blocks and choose what content to import or batch export:",
+        },
+        "image": {
+            "primary_label": "OCR Text",
+            "secondary_label": "OCR Context",
+            "modes": [
+                ("primary_only", "OCR Text Only"),
+                ("combine", "Include OCR Context"),
+            ],
+            "help": "Select OCR rows and choose what text to import or batch export:",
+        },
+    }
+    IMAGE_TYPES = {"png", "jpg", "jpeg", "tif", "tiff", "bmp", "webp"}
 
     def __init__(self, view):
         super().__init__()
@@ -25,6 +153,7 @@ class SecondController(QObject):
         self.import_rows = []
         self.load_thread = None
         self.load_worker = None
+        self.current_mode_map = {}
         self.view.browseButton.clicked.connect(self.choose_file)
         self.view.loadButton.clicked.connect(self.load_file)
         self.view.cancelLoadButton.clicked.connect(self.cancel_load)
@@ -35,6 +164,7 @@ class SecondController(QObject):
             self.view.previewTable.clearSelection
         )
         self.view.closeButton.clicked.connect(self.view.close)
+        self._apply_format_profile(None)
         self._surface_document_dependency_status()
 
     def _selected_rows(self):
@@ -49,9 +179,9 @@ class SecondController(QObject):
         primary_text = (row.get("primary_text") or "").strip()
         secondary_text = (row.get("secondary_text") or "").strip()
 
-        if content_mode == "notes_only":
+        if content_mode == "secondary_only":
             return secondary_text
-        if content_mode == "slide_text_only":
+        if content_mode == "primary_only":
             return primary_text
         if content_mode == "combine":
             parts = [part for part in (primary_text, secondary_text) if part]
@@ -59,7 +189,7 @@ class SecondController(QObject):
         return secondary_text or primary_text
 
     def _build_import_payload(self, selected_rows):
-        content_mode = self.CONTENT_MODE_MAP[
+        content_mode = self.current_mode_map[
             self.view.contentModeComboBox.currentText()
         ]
         payload_rows = []
@@ -91,6 +221,50 @@ class SecondController(QObject):
             self.view.previewTable.setItem(row_index, 2, secondary_cell)
 
         self.view.previewTable.resizeColumnsToContents()
+
+    def _source_type_for_rows(self, rows):
+        source_types = {
+            str(row.get("source_type", "")).lower()
+            for row in rows
+            if row.get("source_type")
+        }
+        if len(source_types) != 1:
+            return None
+
+        source_type = next(iter(source_types))
+        return "image" if source_type in self.IMAGE_TYPES else source_type
+
+    def _profile_for_source_type(self, source_type):
+        return self.FORMAT_PROFILES.get(
+            source_type,
+            {
+                "primary_label": "Primary Text",
+                "secondary_label": "Secondary Text",
+                "modes": [
+                    ("prefer_secondary", "Prefer Secondary Text"),
+                    ("secondary_only", "Secondary Text Only"),
+                    ("primary_only", "Primary Text Only"),
+                    ("combine", "Combine Primary and Secondary Text"),
+                ],
+                "help": "Select document rows and choose what to import or batch export:",
+            },
+        )
+
+    def _apply_format_profile(self, source_type):
+        profile = self._profile_for_source_type(source_type)
+        self.view.previewTable.setHorizontalHeaderLabels(
+            [
+                "Item",
+                profile["primary_label"],
+                profile["secondary_label"],
+            ]
+        )
+        self.view.selectionHelpLabel.setText(profile["help"])
+        self.view.contentModeComboBox.clear()
+        self.current_mode_map = {}
+        for mode_value, mode_label in profile["modes"]:
+            self.view.contentModeComboBox.addItem(mode_label)
+            self.current_mode_map[mode_label] = mode_value
 
     def _set_loading_state(self, is_loading):
         for button_name in (
@@ -176,6 +350,7 @@ class SecondController(QObject):
 
     def _handle_load_finished(self, extracted_rows):
         self.import_rows = extracted_rows
+        self._apply_format_profile(self._source_type_for_rows(extracted_rows))
         self._populate_preview_table()
         if self.import_rows:
             self.view.previewTable.selectAll()

--- a/app/gui/ui_main_window.py
+++ b/app/gui/ui_main_window.py
@@ -119,7 +119,13 @@ class Ui_MainWindow:
         self.historyList = QListWidget(self.historyGroup)
         self.historyList.setAlternatingRowColors(True)
         self.historyList.setSelectionMode(
-            QListWidget.SelectionMode.NoSelection
+            QListWidget.SelectionMode.SingleSelection
+        )
+        self.historyList.setContextMenuPolicy(
+            Qt.ContextMenuPolicy.CustomContextMenu
+        )
+        self.historyList.setToolTip(
+            "Double-click generated audio to play it, or right-click for history actions."
         )
         self.historyGroup.setMaximumHeight(170)
         history_layout.addWidget(self.historyList)
@@ -132,6 +138,8 @@ class Ui_MainWindow:
         self.menuTools = QMenu("Tools", self.menubar)
         self.menuHelp = QMenu("Help", self.menubar)
         self.actionOpenText = QAction("Open Document", main_window)
+        self.actionOpenUrl = QAction("Open URL", main_window)
+        self.actionOpenRawHtml = QAction("Import Raw HTML", main_window)
         self.actionSaveText = QAction("Save Editor Text", main_window)
         self.actionExportAudio = QAction("Export Audio", main_window)
         self.actionExit = QAction("Exit", main_window)
@@ -140,6 +148,8 @@ class Ui_MainWindow:
         self.actionAbout = QAction("About", main_window)
 
         self.menuFile.addAction(self.actionOpenText)
+        self.menuFile.addAction(self.actionOpenUrl)
+        self.menuFile.addAction(self.actionOpenRawHtml)
         self.menuFile.addAction(self.actionSaveText)
         self.menuFile.addAction(self.actionExportAudio)
         self.menuFile.addSeparator()

--- a/app/gui/ui_second_window.py
+++ b/app/gui/ui_second_window.py
@@ -49,14 +49,6 @@ class Ui_Dialog:
             dialog,
         )
         self.contentModeComboBox = QComboBox(dialog)
-        self.contentModeComboBox.addItems(
-            [
-                "Prefer Secondary Text",
-                "Secondary Text Only",
-                "Primary Text Only",
-                "Combine Primary and Secondary Text",
-            ]
-        )
         mode_row.addWidget(self.selectionHelpLabel)
         mode_row.addWidget(self.contentModeComboBox)
         layout.addLayout(mode_row)

--- a/app/model/scraper/document_scraper.py
+++ b/app/model/scraper/document_scraper.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 import importlib.util
 from pathlib import Path
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
 
 
 @dataclass
@@ -182,20 +184,65 @@ class DocumentScraper:
             rows = self._scrape_pptx(path)
         elif suffix in {".png", ".jpg", ".jpeg", ".tif", ".tiff", ".bmp", ".webp"}:
             rows = self._scrape_image(path)
+        return self._rows_to_dicts(rows, path, suffix.lstrip("."))
+
+    def scrape_html_text(
+        self,
+        html,
+        source_name="Pasted HTML",
+        source_path="raw-html",
+        source_type="html",
+    ):
+        """Scrape raw HTML content into the same normalized rows as HTML files."""
+        missing_dependencies = self.missing_dependencies_for_suffix(".html")
+        if missing_dependencies:
+            raise RuntimeError(
+                self.format_missing_dependency_message(missing_dependencies)
+            )
+
+        from bs4 import BeautifulSoup
+
+        soup = BeautifulSoup(html, "html.parser")
+        title = soup.title.get_text(strip=True) if soup.title else source_name
+        rows = self._html_to_rows(soup, title, "html_section")
+        return self._rows_to_dicts(rows, source_path, source_type)
+
+    def scrape_url(self, url, timeout=20):
+        """Fetch a URL and scrape the response body as structured HTML content."""
+        parsed_url = urlparse(url)
+        if parsed_url.scheme not in {"http", "https"}:
+            raise ValueError("URL imports require an http or https address.")
+
+        request = Request(
+            url,
+            headers={"User-Agent": "TextToSpeechPython document importer"},
+        )
+        with urlopen(request, timeout=timeout) as response:
+            charset = response.headers.get_content_charset() or "utf-8"
+            html = response.read().decode(charset, errors="replace")
+
+        return self.scrape_html_text(
+            html,
+            source_name=url,
+            source_path=url,
+            source_type="url",
+        )
+
+    def _rows_to_dicts(self, rows, source_path, source_type):
         return [
-            self._row_to_dict(row, path)
+            self._row_to_dict(row, source_path, source_type)
             for row in rows
             if self._has_content(row)
         ]
 
-    def _row_to_dict(self, row, path):
+    def _row_to_dict(self, row, source_path, source_type):
         return {
             "item_number": row.item_number,
             "title": row.title,
             "primary_text": row.primary_text,
             "secondary_text": row.secondary_text,
-            "source_path": str(path),
-            "source_type": path.suffix.lower().lstrip("."),
+            "source_path": str(source_path),
+            "source_type": source_type,
             "metadata": dict(row.metadata),
         }
 

--- a/docs/gui.rst
+++ b/docs/gui.rst
@@ -17,6 +17,7 @@ The main window includes:
 - an inline guidance label for disabled or unavailable states
 - a recent audio history panel
 - a menu bar with file, tools, and help actions
+- quick source import actions for local documents, URLs, and pasted raw HTML
 
 Settings Dialog
 ---------------
@@ -55,6 +56,8 @@ It provides:
 - secondary text column
 - heading-aware rows for structured documents
 - table, spreadsheet, and slide metadata that preserves source context
+- format-aware labels and content-mode options for pages, slides, chapters,
+  OCR text, and spreadsheet rows
 - multi-row selection
 - content-mode selection
 - import of selected rows into the main editor
@@ -71,6 +74,11 @@ Currently supported file types include:
 - ``.epub``
 - ``.xlsx`` / ``.xls`` / ``.csv``
 - ``.pptx``
+
+The main window additionally supports ``File > Open URL`` and
+``File > Import Raw HTML``. Both flows parse the source through the same
+structured HTML scraper used for local ``.html`` and ``.htm`` files before
+placing the resolved text in the editor.
 
 The app checks parser dependency availability at startup and before loading a
 document. If the active environment is missing a package required by an
@@ -102,5 +110,12 @@ The main window tracks recent generated audio items and displays:
 - voice
 - filename
 - output path
+
+History items are actionable:
+
+- double-click a generated audio item to replay it
+- right-click to open the containing folder
+- right-click to copy the audio path
+- right-click to restore the source text and generation settings snapshot
 
 History is persisted to ``data/dynamic/audio_history.json``.

--- a/poetry.lock
+++ b/poetry.lock
@@ -989,14 +989,14 @@ files = [
 
 [[package]]
 name = "striprtf"
-version = "0.0.31"
+version = "0.0.32"
 description = "A simple library to convert rtf to text"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "striprtf-0.0.31-py3-none-any.whl", hash = "sha256:8ec8150a4213951675f711750a4a5b8a98a6da3ef85deeff0bb6e39cd2beeda4"},
-    {file = "striprtf-0.0.31.tar.gz", hash = "sha256:ce4b6403427d7d5cda95fdb61365432225f6fbe5ea6797e1357f4045d351ba2d"},
+    {file = "striprtf-0.0.32-py3-none-any.whl", hash = "sha256:9f695fea9662cb4ffccf2b56286b3e77028c0a61e87258719584e681e0144869"},
+    {file = "striprtf-0.0.32.tar.gz", hash = "sha256:7f375a375d99a2700842173168c90c9b545cb244241ffc5d868ed9f6baf9155f"},
 ]
 
 [package.extras]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "texttospeechpython"
-version = "0.1.3"
+version = "0.1.4"
 description = "PyQt desktop app for experimenting with Azure text-to-speech and SSML workflows."
 readme = "README.md"
 authors = [{ name = "Thaddeus Thomas" }]

--- a/tests/test_background_workers.py
+++ b/tests/test_background_workers.py
@@ -53,6 +53,23 @@ class BackgroundWorkerTests(unittest.TestCase):
         self.assertFalse(finished)
         self.assertFalse(failed)
 
+    def test_document_parse_worker_can_parse_raw_html_sources(self):
+        finished = []
+        failed = []
+        worker = DocumentParseWorker(
+            "<html><body><h1>Worker HTML</h1><p>Unique worker HTML body.</p></body></html>",
+            source_kind="html",
+        )
+        worker.finished.connect(finished.append)
+        worker.failed.connect(failed.append)
+
+        worker.run()
+
+        self.assertFalse(failed)
+        self.assertEqual(len(finished), 1)
+        self.assertEqual(finished[0][0]["source_type"], "html")
+        self.assertIn("Unique worker HTML body.", finished[0][0]["primary_text"])
+
     def test_batch_export_worker_writes_files_and_reports_progress(self):
         temp_dir = Path("data/dynamic/tmp/batch_worker_test")
         shutil.rmtree(temp_dir, ignore_errors=True)

--- a/tests/test_document_scraper.py
+++ b/tests/test_document_scraper.py
@@ -18,6 +18,27 @@ HAS_OPENPYXL = importlib.util.find_spec("openpyxl") is not None
 HAS_STRIPRTF = importlib.util.find_spec("striprtf") is not None
 
 
+class FakeHeaders:
+    def get_content_charset(self):
+        return "utf-8"
+
+
+class FakeUrlResponse:
+    headers = FakeHeaders()
+
+    def __init__(self, body):
+        self.body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        return False
+
+    def read(self):
+        return self.body
+
+
 def build_pdf_bytes(text):
     objects = [
         b"<< /Type /Catalog /Pages 2 0 R >>",
@@ -172,6 +193,45 @@ class DocumentScraperTests(unittest.TestCase):
         self.assertEqual(rows[0]["title"], "Table 1 Row 1")
         self.assertIn("Step: Import", rows[0]["primary_text"])
         self.assertEqual(rows[0]["metadata"]["kind"], "table_row")
+
+    def test_scrape_html_text_extracts_pasted_html_sections(self):
+        rows = self.scraper.scrape_html_text(
+            (
+                "<html><head><title>Pasted Source</title></head><body>"
+                "<h2>Raw HTML Heading</h2><p>Unique pasted HTML body.</p>"
+                "</body></html>"
+            )
+        )
+
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["title"], "Raw HTML Heading")
+        self.assertEqual(rows[0]["source_path"], "raw-html")
+        self.assertEqual(rows[0]["source_type"], "html")
+        self.assertIn("Unique pasted HTML body.", rows[0]["primary_text"])
+
+    def test_scrape_url_fetches_and_scrapes_html(self):
+        html = (
+            "<html><head><title>Remote Source</title></head><body>"
+            "<h1>Remote Heading</h1><p>Unique URL imported body.</p>"
+            "</body></html>"
+        ).encode("utf-8")
+
+        with patch(
+            "app.model.scraper.document_scraper.urlopen",
+            return_value=FakeUrlResponse(html),
+        ) as mocked_urlopen:
+            rows = self.scraper.scrape_url("https://example.test/article")
+
+        mocked_urlopen.assert_called_once()
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["title"], "Remote Heading")
+        self.assertEqual(rows[0]["source_path"], "https://example.test/article")
+        self.assertEqual(rows[0]["source_type"], "url")
+        self.assertIn("Unique URL imported body.", rows[0]["primary_text"])
+
+    def test_scrape_url_rejects_non_web_schemes(self):
+        with self.assertRaisesRegex(ValueError, "http or https"):
+            self.scraper.scrape_url("file:///tmp/example.html")
 
     def test_scrape_docx_extracts_paragraphs(self):
         docx_path = self.temp_dir / "sample.docx"

--- a/tests/test_main_controller_history.py
+++ b/tests/test_main_controller_history.py
@@ -32,17 +32,44 @@ from app.model.app_settings import AppSettings
 class HistoryListStub:
     def __init__(self):
         self.items = []
+        self.current_row = 0
 
     def clear(self):
         self.items.clear()
 
-    def addItem(self, text):
-        self.items.append(text)
+    def addItem(self, item):
+        self.items.append(item)
+
+    def currentItem(self):
+        if 0 <= self.current_row < len(self.items):
+            return self.items[self.current_row]
+        return None
+
+    def currentRow(self):
+        return self.current_row
+
+
+class StatusBarStub:
+    def __init__(self):
+        self.message = ""
+
+    def showMessage(self, message):
+        self.message = message
+
+
+class TextEditStub:
+    def __init__(self):
+        self.text = ""
+
+    def setPlainText(self, text):
+        self.text = text
 
 
 class ViewStub:
     def __init__(self):
         self.historyList = HistoryListStub()
+        self.statusbar = StatusBarStub()
+        self.textEdit = TextEditStub()
 
 
 class MainControllerHistoryTests(unittest.TestCase):
@@ -61,18 +88,79 @@ class MainControllerHistoryTests(unittest.TestCase):
             controller.AUDIO_HISTORY_PATH = temp_dir / "audio_history.json"
             controller.MAX_HISTORY_ITEMS = 3
 
-            controller._record_audio_history(audio_path, "export")
+            controller._record_audio_history(
+                audio_path,
+                "export",
+                source_text="Unique history source text.",
+            )
 
             self.assertEqual(len(controller.audio_history), 1)
             self.assertEqual(controller.audio_history[0]["filename"], "sample.mp3")
             self.assertEqual(controller.audio_history[0]["voice"], "en-US-GuyNeural")
-            self.assertIn("Export", controller.view.historyList.items[0])
+            self.assertEqual(
+                controller.audio_history[0]["source_text"],
+                "Unique history source text.",
+            )
+            self.assertEqual(
+                controller.audio_history[0]["settings"]["voice"],
+                "en-US-GuyNeural",
+            )
+            self.assertIn("Export", controller.view.historyList.items[0].text())
 
             saved_history = json.loads(
                 controller.AUDIO_HISTORY_PATH.read_text(encoding="utf-8")
             )
             self.assertEqual(saved_history[0]["filename"], "sample.mp3")
             self.assertEqual(saved_history[0]["output_path"], str(audio_path.resolve()))
+            self.assertEqual(
+                saved_history[0]["source_text"],
+                "Unique history source text.",
+            )
+        finally:
+            shutil.rmtree(temp_dir, ignore_errors=True)
+
+    def test_restore_selected_history_context_reuses_text_and_settings(self):
+        temp_dir = Path("data/dynamic/tmp/history_restore_test")
+        shutil.rmtree(temp_dir, ignore_errors=True)
+        temp_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            controller = MainController.__new__(MainController)
+            controller.settings = AppSettings(
+                voice="en-US-GuyNeural",
+                speaking_rate="medium",
+            )
+            controller.view = ViewStub()
+            controller.AUDIO_HISTORY_PATH = temp_dir / "audio_history.json"
+            controller.SETTINGS_PATH = temp_dir / "app_settings.json"
+            controller.tts_processor = object()
+            controller.audio_history = [
+                {
+                    "filename": "sample.mp3",
+                    "output_path": str(temp_dir / "sample.mp3"),
+                    "voice": "en-US-JennyNeural",
+                    "generated_at": "20260427010101",
+                    "source": "export",
+                    "source_text": "Restore this narration text.",
+                    "settings": {
+                        "voice": "en-US-JennyNeural",
+                        "speaking_rate": "slow",
+                    },
+                }
+            ]
+            controller._refresh_ui_state = lambda: None
+            controller.update_ssml_preview = lambda: None
+            controller._refresh_history_panel()
+
+            controller.restore_selected_history_context()
+
+            self.assertEqual(controller.view.textEdit.text, "Restore this narration text.")
+            self.assertEqual(controller.settings.voice, "en-US-JennyNeural")
+            self.assertEqual(controller.settings.speaking_rate, "slow")
+            self.assertIsNone(controller.tts_processor)
+            self.assertEqual(
+                controller.view.statusbar.message,
+                "Restored history text and settings.",
+            )
         finally:
             shutil.rmtree(temp_dir, ignore_errors=True)
 

--- a/tests/test_second_controller_import.py
+++ b/tests/test_second_controller_import.py
@@ -4,22 +4,64 @@ from app.controller.second_controller import SecondController
 
 
 class ComboBoxStub:
-    def __init__(self, text):
+    def __init__(self, text=""):
+        self.items = []
         self._text = text
 
     def currentText(self):
         return self._text
 
+    def clear(self):
+        self.items.clear()
+
+    def addItem(self, text):
+        self.items.append(text)
+        if not self._text:
+            self._text = text
+
+    def setCurrentText(self, text):
+        self._text = text
+
+
+class LabelStub:
+    def __init__(self):
+        self.text = ""
+
+    def setText(self, text):
+        self.text = text
+
+
+class TableStub:
+    def __init__(self):
+        self.headers = []
+
+    def setHorizontalHeaderLabels(self, labels):
+        self.headers = labels
+
 
 class ViewStub:
     def __init__(self, mode_text):
         self.contentModeComboBox = ComboBoxStub(mode_text)
+        self.previewTable = TableStub()
+        self.selectionHelpLabel = LabelStub()
 
 
 class SecondControllerImportTests(unittest.TestCase):
     def _controller(self, mode_text="Prefer Secondary Text"):
         controller = SecondController.__new__(SecondController)
         controller.view = ViewStub(mode_text)
+        controller.current_mode_map = {
+            "Prefer Secondary Text": "prefer_secondary",
+            "Secondary Text Only": "secondary_only",
+            "Primary Text Only": "primary_only",
+            "Combine Primary and Secondary Text": "combine",
+            "Prefer Speaker Notes": "prefer_secondary",
+            "Speaker Notes Only": "secondary_only",
+            "Slide Text Only": "primary_only",
+            "Combine Slide Text and Speaker Notes": "combine",
+            "Row Text Only": "primary_only",
+            "Include Sheet and Column Context": "combine",
+        }
         return controller
 
     def test_build_import_payload_prefers_secondary_with_primary_fallback(self):
@@ -65,6 +107,46 @@ class SecondControllerImportTests(unittest.TestCase):
             "Agenda\n\nLonger narration",
         )
         self.assertEqual(imported_text, "Agenda\n\nLonger narration")
+
+    def test_apply_format_profile_uses_slide_specific_terms_for_pptx(self):
+        controller = self._controller("")
+
+        controller._apply_format_profile("pptx")
+
+        self.assertEqual(
+            controller.view.previewTable.headers,
+            ["Item", "Slide Text", "Speaker Notes"],
+        )
+        self.assertIn("Speaker Notes Only", controller.view.contentModeComboBox.items)
+        self.assertIn("slides", controller.view.selectionHelpLabel.text)
+
+    def test_apply_format_profile_uses_page_terms_for_pdf(self):
+        controller = self._controller("")
+
+        controller._apply_format_profile("pdf")
+
+        self.assertEqual(
+            controller.view.previewTable.headers,
+            ["Item", "Page Text", "Page Context"],
+        )
+        self.assertEqual(
+            controller.current_mode_map["Page Text Only"],
+            "primary_only",
+        )
+
+    def test_apply_format_profile_uses_spreadsheet_terms_for_xlsx(self):
+        controller = self._controller("")
+
+        controller._apply_format_profile("xlsx")
+
+        self.assertEqual(
+            controller.view.previewTable.headers,
+            ["Item", "Row Text", "Sheet / Column Context"],
+        )
+        self.assertEqual(
+            controller.current_mode_map["Include Sheet and Column Context"],
+            "combine",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This PR closes #47, closes #48, and closes #49.

It improves the document-to-audio workflow by making imports more format-aware, adding first-class URL/raw HTML source import, and turning recent audio history into an actionable workflow tool.

## Changes

- Added format-aware import labels and content modes so TXT, PDF, DOCX, HTML, EPUB, spreadsheets, images/OCR, and PPTX use clearer wording instead of generic primary/secondary text everywhere.
- Added main-window source actions for `File > Open URL` and `File > Import Raw HTML`.
- Routed URL and raw HTML content through the same structured HTML scraper path used by local HTML files.
- Extended background document parsing so file, URL, and raw HTML sources use the same worker flow.
- Made the Recent Audio panel selectable and actionable.
- Added double-click replay for recent audio history items.
- Added right-click history actions for play, open containing folder, copy audio path, and restore previous source text/settings.
- Stored source text and relevant synthesis settings with new audio history entries.
- Updated README and GUI docs for the new import and history workflows.
- Added regression tests for format-aware import behavior, URL/raw HTML scraping, worker parsing, and history restore behavior.

## Verification

- `poetry run python -m unittest discover -s tests`
- `poetry check`
- `git diff --check`

## Issues Closed

Closes #47
Closes #48
Closes #49