### PR TITLE
Add collapsible settings/sidebar UX polish and status/history layout refinements

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,12 @@ The current application supports:
 - editing or pasting source text in the main window
 - live SSML preview generation
 - Azure Speech synthesis to preview or exported `.mp3` files
-- a settings dialog for Azure credentials, voice, output directory, logging,
+- a collapsible settings sidebar for Azure credentials, voice, output directory, logging,
   playback volume, and advanced SSML controls
 - document import for `.txt`, `.docx`, `.pdf`, `.html`, `.htm`, `.rtf`,
-  `.epub`, `.xlsx`, `.xls`, `.csv`, and `.pptx`
+  `.epub`, `.xlsx`, `.xls`, `.csv`, `.pptx`, and common image formats
+- OCR extraction for scanned PDFs and image documents when Tesseract OCR is
+  installed locally
 - direct import of web URLs and pasted raw HTML through the same document
   extraction path
 - selective import of extracted document sections into the main editor
@@ -27,6 +29,7 @@ The current application supports:
 - Python 3.11+
 - Poetry
 - Azure Speech resource with a valid key and region
+- Tesseract OCR for scanned PDFs and image imports
 
 ## Installation
 
@@ -40,6 +43,11 @@ This install path includes the parser libraries needed for every format shown
 in the document import dialog. If the active interpreter is missing one of those
 packages, the app shows a startup/import warning and asks you to run
 `poetry install`.
+
+OCR support also requires the Tesseract OCR executable to be installed on the
+user's machine and available on `PATH`. Poetry installs the Python bridge
+package (`pytesseract`), but it cannot install the operating-system OCR engine
+itself.
 
 ## Version Bumping
 
@@ -76,7 +84,7 @@ unavailable until credentials are provided.
 
 You can configure Azure Speech in either of these ways:
 
-1. In the GUI via `Tools > Settings`
+1. In the GUI via `Tools > Settings`, then the settings sidebar `Apply` button
 2. With a local `.env` file in INI format
 
 Example `.env`:
@@ -93,7 +101,7 @@ GUI settings take precedence over `.env` when both are present.
 
 1. Paste text into the editor, open a local document, open a URL, import raw
    HTML, or use `Import Document` for row-based selection.
-2. Open `Tools > Settings` to configure Azure, voice, output directory, and SSML options.
+2. Open `Tools > Settings` to expand the settings sidebar and configure Azure, voice, output directory, and SSML options.
 3. Review the generated SSML preview.
 4. Use `Generate & Play` for a temporary preview file or `Generate File` to export an `.mp3`.
 5. Review, replay, copy, reopen, or restore previous work from the `Recent Audio` panel.
@@ -108,7 +116,8 @@ original structured format.
 
 ## Advanced SSML Controls
 
-The settings dialog includes an expandable advanced SSML section. The current
+The settings sidebar includes an expandable advanced SSML section and can stay
+open while you edit narration text. The current
 GUI exposes:
 
 - emphasis
@@ -127,10 +136,14 @@ These controls are applied to both the SSML preview and generated audio.
 - heading-aware rows for DOCX, HTML, and EPUB content where available
 - table and spreadsheet rows that keep sheet, column, and table context
 - format-aware column labels and import modes, such as slide notes, page text,
-  chapter text, OCR text, or spreadsheet row context
+  chapter text, OCR text, image text, or spreadsheet row context
 - multi-row selection
 - content modes that adapt to the loaded format, such as page text, slide
-  notes, chapter text, OCR text, or spreadsheet row context
+  notes, chapter text, OCR text, image text, or spreadsheet row context
+
+Supported local source types include `.txt`, `.docx`, `.pdf`, `.html`, `.htm`,
+`.rtf`, `.epub`, `.xlsx`, `.xls`, `.csv`, `.pptx`, `.png`, `.jpg`, `.jpeg`,
+`.tif`, `.tiff`, `.bmp`, and `.webp`.
 
 From that dialog you can:
 
@@ -144,7 +157,7 @@ parsed as structured HTML sections before being placed in the editor.
 
 ## Logging
 
-If logging is enabled in `Tools > Settings`, the application writes logs to:
+If logging is enabled from the settings sidebar, the application writes logs to:
 
 ```text
 data/dynamic/logs/app.log
@@ -161,6 +174,7 @@ YYYYMMDDHHmmss
 The `Recent Audio` panel keeps the latest generated files and supports workflow
 actions:
 
+- collapse or expand the panel with the `-` / `+` control
 - double-click a history item to replay it
 - right-click to open the containing folder
 - right-click to copy the generated audio path

--- a/app/assets/styles/styles.qss
+++ b/app/assets/styles/styles.qss
@@ -13,9 +13,9 @@ QDialog {
 QGroupBox {
     background-color: rgba(255, 252, 247, 0.92);
     border: 1px solid #d7c8b3;
-    border-radius: 14px;
-    margin-top: 12px;
-    padding: 14px 14px 12px 14px;
+    border-radius: 10px;
+    margin-top: 10px;
+    padding: 9px 10px 8px 10px;
     font-weight: 600;
 }
 
@@ -26,8 +26,22 @@ QGroupBox::title {
     color: #6d4c33;
 }
 
+QGroupBox#historyGroup {
+    margin-top: 8px;
+    padding: 6px 10px 10px 10px;
+}
+
+QWidget#historyHeader {
+    background: transparent;
+}
+
 QLabel {
     background: transparent;
+}
+
+QLabel#historyTitleLabel {
+    color: #6d4c33;
+    font-weight: 700;
 }
 
 QLabel#actionHintLabel,
@@ -39,10 +53,22 @@ QPushButton {
     background-color: #b85c38;
     color: #fff8f2;
     border: 1px solid #9c4826;
-    border-radius: 10px;
+    border-radius: 8px;
     padding: 8px 14px;
     font-weight: 600;
     min-height: 18px;
+}
+
+QToolButton#historyToggleButton {
+    background-color: #eadbc6;
+    color: #5b412d;
+    border: 1px solid #d2bea4;
+    border-radius: 6px;
+    font-weight: 800;
+}
+
+QToolButton#historyToggleButton:hover {
+    background-color: #dfcab0;
 }
 
 QPushButton:hover {
@@ -67,7 +93,7 @@ QTableWidget,
 QComboBox {
     background-color: #fffdf9;
     border: 1px solid #cfbea8;
-    border-radius: 10px;
+    border-radius: 7px;
     padding: 6px 8px;
     selection-background-color: #d88c62;
     selection-color: #fff9f4;

--- a/app/controller/main_controller.py
+++ b/app/controller/main_controller.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import tempfile
 from datetime import datetime
 from xml.sax.saxutils import escape
+from loguru import logger
 
 from PyQt6.QtCore import QObject, Qt, QThread, QUrl
 from PyQt6.QtGui import QDesktopServices
@@ -37,7 +38,6 @@ from app.model.scraper.document_scraper import DocumentScraper
 from app.model.ssml.ssml_config import SSMLConfig
 from app.utils.logging_config import configure_logging
 from app.utils.text_cleaner import TextCleaner
-from loguru import logger
 
 
 class MainController(QObject):
@@ -100,7 +100,7 @@ class MainController(QObject):
 
     def _connect_signals(self):
         self.view.openSecondWindowButton.clicked.connect(self.open_second_window)
-        self.view.openSettingsButton.clicked.connect(self.open_settings)
+        self.view.openSettingsButton.clicked.connect(self.toggle_settings_sidebar)
         self.view.previewButton.clicked.connect(self.update_ssml_preview)
         self.view.cleanTextButton.clicked.connect(self.clean_text)
         self.view.playButton.clicked.connect(self.generate_and_play_audio)
@@ -116,7 +116,7 @@ class MainController(QObject):
         self.view.actionExportEditorText.triggered.connect(self.export_editor_text)
         self.view.actionExportAudio.triggered.connect(self.export_audio_file)
         self.view.actionExit.triggered.connect(self.view.close)
-        self.view.actionSettings.triggered.connect(self.open_settings)
+        self.view.actionSettings.triggered.connect(self.toggle_settings_sidebar)
         self.view.actionOpenScraper.triggered.connect(self.open_second_window)
         self.view.actionAbout.triggered.connect(self.show_about)
         self.view.textEdit.textChanged.connect(self._handle_editor_text_changed)
@@ -126,26 +126,34 @@ class MainController(QObject):
         self.view.historyList.customContextMenuRequested.connect(
             self.show_history_context_menu
         )
+        self.view.historyToggleButton.clicked.connect(self.toggle_recent_audio)
+        self.view.applySidebarSettingsButton.clicked.connect(
+            self.apply_sidebar_settings
+        )
+        self.view.collapseSettingsSidebarButton.clicked.connect(
+            self.hide_settings_sidebar
+        )
 
     def _sanitize_batch_name(self, value):
         return sanitize_batch_name(value)
 
     def _refresh_ui_state(self):
         self._updating_ui_state = True
-        self.view.voiceSummaryLabel.setText(f"Voice: {self.settings.voice}")
-        self.view.rateSummaryLabel.setText(
-            f"Rate: {self.settings.speaking_rate}"
-        )
-        self.view.volumeSummaryLabel.setText(
-            f"Speech Volume: {self.settings.synthesis_volume}"
-        )
-        self.view.outputSummaryLabel.setText(
-            f"Output: {self.settings.output_dir}"
+        self.view.outputStatusLabel.setText(
+            " | ".join(
+                (
+                    f"Voice: {self.settings.voice}",
+                    f"Rate: {self.settings.speaking_rate}",
+                    f"Speech Volume: {self.settings.synthesis_volume}",
+                    f"Output: {self.settings.output_dir}",
+                )
+            )
         )
         self.view.playbackVolumeSlider.setValue(self.settings.playback_volume)
         self.view.playbackVolumeValueLabel.setText(
             f"{self.settings.playback_volume}%"
         )
+        self.view.sidebarSettingsEditor.set_settings(self.settings)
         self._refresh_action_states()
         azure_key, azure_region = self._resolve_azure_credentials()
         if azure_key and azure_region:
@@ -318,6 +326,26 @@ class MainController(QObject):
             )
             item.setData(Qt.ItemDataRole.UserRole, entry)
             self.view.historyList.addItem(item)
+
+    def toggle_recent_audio(self):
+        should_expand = self.view.historyList.isHidden()
+        self.view.historyList.setVisible(should_expand)
+
+        if should_expand:
+            self.view.historyToggleButton.setText("-")
+            self.view.historyToggleButton.setToolTip("Collapse Recent Audio")
+            self.view.historyGroup.setMaximumHeight(170)
+            self.view.historyGroup.setMinimumHeight(48)
+            self.view.statusbar.showMessage("Recent audio expanded.")
+            logger.info("Expanded recent audio panel.")
+            return
+
+        self.view.historyToggleButton.setText("+")
+        self.view.historyToggleButton.setToolTip("Expand Recent Audio")
+        self.view.historyGroup.setMaximumHeight(48)
+        self.view.historyGroup.setMinimumHeight(48)
+        self.view.statusbar.showMessage("Recent audio collapsed.")
+        logger.info("Collapsed recent audio panel.")
 
     def _history_settings_snapshot(self):
         return {
@@ -575,8 +603,8 @@ class MainController(QObject):
                 "Azure Setup Required",
                 (
                     "The application could not find valid Azure Speech credentials.\n\n"
-                    "Open Tools > Settings and enter your Azure key and region, "
-                    "or create a valid .env file."
+                    "Open Tools > Settings, enter your Azure key and region, "
+                    "and click Apply, or create a valid .env file."
                 ),
             )
             self.view.statusbar.showMessage(
@@ -695,8 +723,8 @@ class MainController(QObject):
                 "Azure Setup Required",
                 (
                     "The application could not find valid Azure Speech credentials.\n\n"
-                    "Open Tools > Settings and enter your Azure key and region, "
-                    "or create a valid .env file."
+                    "Open Tools > Settings, enter your Azure key and region, "
+                    "and click Apply, or create a valid .env file."
                 ),
             )
             self.view.statusbar.showMessage(
@@ -1027,8 +1055,7 @@ class MainController(QObject):
         )
         logger.info("Exported editor contents to {}", file_path)
 
-    def open_settings(self):
-        updated_settings = self.settings_controller.edit_settings(self.settings)
+    def _apply_updated_settings(self, updated_settings):
         if updated_settings is None:
             return
 
@@ -1041,6 +1068,37 @@ class MainController(QObject):
         self.view.statusbar.showMessage("Settings updated.")
         if self.settings.logging_enabled and log_file is not None:
             logger.info("Settings updated and logging enabled at {}", log_file)
+
+    def open_settings(self):
+        updated_settings = self.settings_controller.edit_settings(self.settings)
+        self._apply_updated_settings(updated_settings)
+
+    def toggle_settings_sidebar(self):
+        if self.view.settingsSidebar.isVisible():
+            self.hide_settings_sidebar()
+            return
+
+        self.view.sidebarSettingsEditor.set_settings(self.settings)
+        self.view.settingsSidebar.show()
+        self.view.openSettingsButton.setText("Hide Settings")
+        self.view.statusbar.showMessage(
+            "Settings sidebar expanded. Adjust options and apply when ready."
+        )
+        logger.info("Expanded settings sidebar.")
+
+    def hide_settings_sidebar(self):
+        self.view.settingsSidebar.hide()
+        self.view.openSettingsButton.setText("Settings")
+        self.view.statusbar.showMessage("Settings sidebar collapsed.")
+        logger.info("Collapsed settings sidebar.")
+
+    def apply_sidebar_settings(self):
+        updated_settings = self.view.sidebarSettingsEditor.get_settings()
+        if updated_settings is None:
+            return
+
+        self._apply_updated_settings(updated_settings)
+        self.view.statusbar.showMessage("Settings applied from sidebar.")
 
     def open_second_window(self):
         if self.second_window and self.second_window.isVisible():

--- a/app/gui/settings_dialog.py
+++ b/app/gui/settings_dialog.py
@@ -24,9 +24,9 @@ from app.model.app_settings import AppSettings
 from app.model.ssml.ssml_config import SSMLConfig
 
 
-class SettingsDialog(QDialog):
+class SettingsEditor(QWidget):
     """
-    Modal dialog for editing application settings.
+    Reusable settings editor used by both the modal dialog and main sidebar.
     """
 
     RATE_OPTIONS = ["x-slow", "slow", "medium", "fast", "x-fast"]
@@ -39,7 +39,6 @@ class SettingsDialog(QDialog):
 
     def __init__(self, settings, parent=None):
         super().__init__(parent)
-        self.setWindowTitle("Settings")
         self.settings = AppSettings(**settings.__dict__)
         self.voice_config = SSMLConfig()
         self._build_ui()
@@ -145,16 +144,6 @@ class SettingsDialog(QDialog):
 
         main_layout.addLayout(form_layout)
 
-        button_row = QHBoxLayout()
-        self.save_button = QPushButton("Save", self)
-        self.cancel_button = QPushButton("Cancel", self)
-        self.save_button.clicked.connect(self._accept_if_valid)
-        self.cancel_button.clicked.connect(self.reject)
-        button_row.addStretch(1)
-        button_row.addWidget(self.save_button)
-        button_row.addWidget(self.cancel_button)
-        main_layout.addLayout(button_row)
-
     def _load_settings(self):
         self.voice_combo.setCurrentText(self.settings.voice)
         self.azure_key_edit.setText(self.settings.azure_key)
@@ -181,6 +170,10 @@ class SettingsDialog(QDialog):
         self.advanced_group.setChecked(show_advanced)
         self._toggle_advanced_controls(show_advanced)
         self._update_playback_label(self.settings.playback_volume)
+
+    def set_settings(self, settings):
+        self.settings = AppSettings(**settings.__dict__)
+        self._load_settings()
 
     def _update_playback_label(self, value):
         self.playback_volume_label.setText(f"{value}%")
@@ -225,10 +218,6 @@ class SettingsDialog(QDialog):
         self.settings.logging_enabled = self.logging_checkbox.isChecked()
         return self.settings
 
-    def _accept_if_valid(self):
-        if self.get_settings() is not None:
-            self.accept()
-
     def _test_connection(self):
         azure_key = self.azure_key_edit.text().strip()
         azure_region = self.azure_region_edit.text().strip()
@@ -265,3 +254,36 @@ class SettingsDialog(QDialog):
 
     def _toggle_advanced_controls(self, enabled):
         self.advanced_controls_widget.setVisible(enabled)
+
+
+class SettingsDialog(QDialog):
+    """
+    Modal dialog for editing application settings.
+    """
+
+    def __init__(self, settings, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Settings")
+        self.editor = SettingsEditor(settings, self)
+        self._build_ui()
+
+    def _build_ui(self):
+        main_layout = QVBoxLayout(self)
+        main_layout.addWidget(self.editor)
+
+        button_row = QHBoxLayout()
+        self.save_button = QPushButton("Save", self)
+        self.cancel_button = QPushButton("Cancel", self)
+        self.save_button.clicked.connect(self._accept_if_valid)
+        self.cancel_button.clicked.connect(self.reject)
+        button_row.addStretch(1)
+        button_row.addWidget(self.save_button)
+        button_row.addWidget(self.cancel_button)
+        main_layout.addLayout(button_row)
+
+    def get_settings(self):
+        return self.editor.get_settings()
+
+    def _accept_if_valid(self):
+        if self.get_settings() is not None:
+            self.accept()

--- a/app/gui/ui_main_window.py
+++ b/app/gui/ui_main_window.py
@@ -14,10 +14,13 @@ from PyQt6.QtWidgets import (
     QSplitter,
     QStatusBar,
     QTextEdit,
+    QToolButton,
     QVBoxLayout,
     QWidget,
 )
 from PyQt6.QtCore import Qt
+from app.gui.settings_dialog import SettingsEditor
+from app.model.app_settings import AppSettings
 
 
 class Ui_MainWindow:
@@ -28,7 +31,10 @@ class Ui_MainWindow:
     def setupUi(self, main_window):
         main_window.setWindowTitle("Text To Speech")
         central_widget = QWidget(main_window)
-        root_layout = QVBoxLayout(central_widget)
+        outer_layout = QHBoxLayout(central_widget)
+        main_panel = QWidget(central_widget)
+        root_layout = QVBoxLayout(main_panel)
+        outer_layout.addWidget(main_panel, 1)
 
         self.audioControlsGroup = QGroupBox("Actions", central_widget)
         action_row = QHBoxLayout(self.audioControlsGroup)
@@ -70,6 +76,7 @@ class Ui_MainWindow:
         action_row.addStretch(1)
         action_row.addWidget(self.playbackVolumeSlider)
         action_row.addWidget(self.playbackVolumeValueLabel)
+
         root_layout.addWidget(self.audioControlsGroup)
 
         self.actionHintLabel = QLabel(
@@ -81,24 +88,6 @@ class Ui_MainWindow:
         root_layout.addWidget(self.actionHintLabel)
 
         content_row = QHBoxLayout()
-
-        self.statusGroup = QGroupBox("Current Output", central_widget)
-        status_layout = QVBoxLayout(self.statusGroup)
-        self.voiceSummaryLabel = QLabel("Voice: en-US-GuyNeural", self.statusGroup)
-        self.rateSummaryLabel = QLabel("Rate: medium", self.statusGroup)
-        self.volumeSummaryLabel = QLabel("Speech Volume: medium", self.statusGroup)
-        self.outputSummaryLabel = QLabel("Output: data/dynamic/audio", self.statusGroup)
-        for label in (
-            self.voiceSummaryLabel,
-            self.rateSummaryLabel,
-            self.volumeSummaryLabel,
-            self.outputSummaryLabel,
-        ):
-            label.setWordWrap(True)
-            status_layout.addWidget(label)
-        status_layout.addStretch(1)
-        self.statusGroup.setMaximumWidth(280)
-        content_row.addWidget(self.statusGroup)
 
         self.editorSplitter = QSplitter(Qt.Orientation.Horizontal, central_widget)
         self.textEdit = QTextEdit(self.editorSplitter)
@@ -114,8 +103,26 @@ class Ui_MainWindow:
         content_row.addWidget(self.editorSplitter, 1)
         root_layout.addLayout(content_row, 1)
 
-        self.historyGroup = QGroupBox("Recent Audio", central_widget)
+        self.historyGroup = QGroupBox(central_widget)
+        self.historyGroup.setObjectName("historyGroup")
         history_layout = QVBoxLayout(self.historyGroup)
+        history_layout.setContentsMargins(10, 6, 10, 10)
+        history_layout.setSpacing(4)
+        self.historyHeader = QWidget(self.historyGroup)
+        self.historyHeader.setObjectName("historyHeader")
+        history_header_layout = QHBoxLayout(self.historyHeader)
+        history_header_layout.setContentsMargins(0, 0, 0, 0)
+        self.historyTitleLabel = QLabel("Recent Audio", self.historyHeader)
+        self.historyTitleLabel.setObjectName("historyTitleLabel")
+        history_header_layout.addWidget(self.historyTitleLabel)
+        history_header_layout.addStretch(1)
+        self.historyToggleButton = QToolButton(self.historyGroup)
+        self.historyToggleButton.setObjectName("historyToggleButton")
+        self.historyToggleButton.setText("-")
+        self.historyToggleButton.setToolTip("Collapse Recent Audio")
+        self.historyToggleButton.setFixedSize(22, 22)
+        history_header_layout.addWidget(self.historyToggleButton)
+        history_layout.addWidget(self.historyHeader)
         self.historyList = QListWidget(self.historyGroup)
         self.historyList.setAlternatingRowColors(True)
         self.historyList.setSelectionMode(
@@ -128,8 +135,35 @@ class Ui_MainWindow:
             "Double-click generated audio to play it, or right-click for history actions."
         )
         self.historyGroup.setMaximumHeight(170)
+        self.historyGroup.setMinimumHeight(48)
         history_layout.addWidget(self.historyList)
         root_layout.addWidget(self.historyGroup)
+
+        self.settingsSidebar = QGroupBox("Settings", central_widget)
+        self.settingsSidebar.setObjectName("settingsSidebar")
+        settings_sidebar_layout = QVBoxLayout(self.settingsSidebar)
+        self.sidebarSettingsEditor = SettingsEditor(
+            AppSettings(),
+            self.settingsSidebar,
+        )
+        settings_sidebar_layout.addWidget(self.sidebarSettingsEditor, 1)
+        sidebar_button_row = QHBoxLayout()
+        self.applySidebarSettingsButton = QPushButton(
+            "Apply",
+            self.settingsSidebar,
+        )
+        self.collapseSettingsSidebarButton = QPushButton(
+            "Collapse",
+            self.settingsSidebar,
+        )
+        sidebar_button_row.addStretch(1)
+        sidebar_button_row.addWidget(self.applySidebarSettingsButton)
+        sidebar_button_row.addWidget(self.collapseSettingsSidebarButton)
+        settings_sidebar_layout.addLayout(sidebar_button_row)
+        self.settingsSidebar.setMinimumWidth(320)
+        self.settingsSidebar.setMaximumWidth(420)
+        self.settingsSidebar.hide()
+        outer_layout.addWidget(self.settingsSidebar)
 
         main_window.setCentralWidget(central_widget)
 
@@ -164,4 +198,19 @@ class Ui_MainWindow:
         main_window.setMenuBar(self.menubar)
 
         self.statusbar = QStatusBar(main_window)
+        self.outputStatusLabel = QLabel(
+            "Voice: en-US-GuyNeural | Rate: medium | Speech Volume: medium | Output: data/dynamic/audio",
+            self.statusbar,
+        )
+        self.outputStatusLabel.setObjectName("outputStatusLabel")
+        self.outputStatusLabel.setAlignment(
+            Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter
+        )
+        self.outputStatusLabel.setTextInteractionFlags(
+            Qt.TextInteractionFlag.TextSelectableByMouse
+        )
+        self.outputStatusLabel.setToolTip(
+            "Current voice, rate, speech volume, and output location."
+        )
+        self.statusbar.addPermanentWidget(self.outputStatusLabel, 1)
         main_window.setStatusBar(self.statusbar)

--- a/docs/api_config.md
+++ b/docs/api_config.md
@@ -7,11 +7,14 @@ The current desktop application supports two Azure Speech configuration paths:
 
 ## Recommended Path
 
-Use the in-app settings dialog for day-to-day use. The GUI supports:
+Use the in-app settings sidebar for day-to-day use. `Tools > Settings` expands
+the sidebar without closing the editor, and `Apply` persists the current values.
+The GUI supports:
 
 - Azure key
 - Azure region
 - connection testing
+- voice, output directory, playback, logging, and SSML defaults
 
 These values are persisted to:
 
@@ -21,7 +24,7 @@ data/dynamic/app_settings.json
 
 ## `.env` Fallback
 
-If the settings dialog does not contain Azure credentials, the application falls
+If the saved GUI settings do not contain Azure credentials, the application falls
 back to a local `.env` file.
 
 Expected format:

--- a/docs/gui.rst
+++ b/docs/gui.rst
@@ -13,18 +13,26 @@ The main window includes:
 - a read-only SSML preview panel
 - action buttons for preview, cleaning, generation, export-related flow, and
   document import
+- a right-aligned status bar output summary for voice, rate, speech volume, and
+  output path
+- a collapsible settings sidebar that can stay open while editing
 - a File menu action for exporting the current editor text to text, Markdown,
   or generated HTML
 - a playback volume control
 - an inline guidance label for disabled or unavailable states
-- a recent audio history panel
+- a collapsible recent audio history panel
 - a menu bar with file, tools, and help actions
 - quick source import actions for local documents, URLs, and pasted raw HTML
 
-Settings Dialog
----------------
+Settings Sidebar
+----------------
 
-The settings dialog currently supports:
+Settings are available from the main window as a collapsible sidebar so users
+can adjust generation options while editing text. The settings editor is shared
+internally so validation, persistence, and connection testing stay consistent
+across the application.
+
+The settings editor currently supports:
 
 - Azure key
 - Azure region
@@ -44,6 +52,9 @@ It also includes an advanced SSML section with:
 - pitch range
 - pause duration
 - pause position
+
+The sidebar can be expanded from the Settings action, applied without leaving
+the editor, and collapsed when the user needs more horizontal workspace.
 
 Document Import Dialog
 ----------------------
@@ -76,6 +87,12 @@ Currently supported file types include:
 - ``.epub``
 - ``.xlsx`` / ``.xls`` / ``.csv``
 - ``.pptx``
+- ``.png`` / ``.jpg`` / ``.jpeg`` / ``.tif`` / ``.tiff`` / ``.bmp`` /
+  ``.webp``
+
+Scanned PDF and image imports use OCR. The Python OCR packages are installed by
+``poetry install``, but the local Tesseract OCR executable must also be
+installed on the user's machine and available on ``PATH``.
 
 The main window additionally supports ``File > Open URL`` and
 ``File > Import Raw HTML``. Both flows parse the source through the same
@@ -109,6 +126,8 @@ Examples:
 - the preview button text changes when only file generation is possible
 - long-running document-load and batch-export work exposes cancel controls while
   the worker is active
+- the settings sidebar starts collapsed and can be expanded, applied, or
+  collapsed without closing the main editor
 
 Automated Qt interaction tests cover main-window menu actions, recent-audio
 history affordances, import-dialog loading states, loaded-row selection, and
@@ -131,5 +150,6 @@ History items are actionable:
 - right-click to open the containing folder
 - right-click to copy the audio path
 - right-click to restore the source text and generation settings snapshot
+- use the ``-`` / ``+`` control to collapse or expand the panel
 
 History is persisted to ``data/dynamic/audio_history.json``.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,3 +11,9 @@ Contents
    :maxdepth: 2
 
    gui
+
+Supporting Guides
+-----------------
+
+- `Azure configuration <api_config.md>`_
+- `SSML attributes reference <ssml_attributes.md>`_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "texttospeechpython"
-version = "0.1.6"
+version = "0.1.7"
 description = "PyQt desktop app for experimenting with Azure text-to-speech and SSML workflows."
 readme = "README.md"
 authors = [{ name = "Thaddeus Thomas" }]

--- a/tests/test_qt_interaction_flows.py
+++ b/tests/test_qt_interaction_flows.py
@@ -1,9 +1,11 @@
 from PyQt6.QtCore import Qt
 from PyQt6.QtWidgets import QMainWindow
 
+from app.controller.main_controller import MainController
 from app.controller.second_controller import SecondController
 from app.gui.second_window import SecondApp
 from app.gui.ui_main_window import Ui_MainWindow
+from app.model.app_settings import AppSettings
 
 
 def test_file_menu_exposes_source_and_export_actions(qtbot):
@@ -38,6 +40,82 @@ def test_history_list_is_actionable_from_real_widget(qtbot):
     assert ui.historyList.contextMenuPolicy() == Qt.ContextMenuPolicy.CustomContextMenu
     assert "Double-click" in ui.historyList.toolTip()
     assert "right-click" in ui.historyList.toolTip()
+    assert ui.historyTitleLabel.text() == "Recent Audio"
+    assert ui.historyToggleButton.text() == "-"
+
+
+def test_recent_audio_toggle_collapses_and_expands_panel(qtbot):
+    window = QMainWindow()
+    qtbot.addWidget(window)
+    ui = Ui_MainWindow()
+    ui.setupUi(window)
+    controller = MainController.__new__(MainController)
+    controller.view = ui
+    window.show()
+    qtbot.waitExposed(window)
+
+    controller.toggle_recent_audio()
+
+    assert ui.historyList.isHidden()
+    assert ui.historyToggleButton.text() == "+"
+    assert "Expand" in ui.historyToggleButton.toolTip()
+    assert ui.historyGroup.maximumHeight() == 48
+    assert ui.historyGroup.minimumHeight() == 48
+    assert ui.historyTitleLabel.isVisible()
+
+    controller.toggle_recent_audio()
+
+    assert not ui.historyList.isHidden()
+    assert ui.historyToggleButton.text() == "-"
+    assert "Collapse" in ui.historyToggleButton.toolTip()
+    assert ui.historyGroup.maximumHeight() == 170
+
+
+def test_output_summary_is_right_aligned_statusbar_text(qtbot):
+    window = QMainWindow()
+    qtbot.addWidget(window)
+    ui = Ui_MainWindow()
+    ui.setupUi(window)
+    window.resize(1200, 620)
+    window.show()
+    qtbot.waitExposed(window)
+
+    assert ui.settingsSidebar.isHidden()
+    assert ui.outputStatusLabel.parent() == ui.statusbar
+    assert ui.outputStatusLabel.alignment() & Qt.AlignmentFlag.AlignRight
+    assert "Voice:" in ui.outputStatusLabel.text()
+    assert ui.outputStatusLabel.width() > ui.statusbar.width() // 2
+
+
+def test_settings_sidebar_toggle_and_apply_uses_main_window_editor(qtbot):
+    window = QMainWindow()
+    qtbot.addWidget(window)
+    ui = Ui_MainWindow()
+    ui.setupUi(window)
+    controller = MainController.__new__(MainController)
+    controller.view = ui
+    controller.settings = AppSettings(
+        voice="en-US-GuyNeural",
+        output_dir="data/dynamic/audio",
+    )
+    applied_settings = []
+    controller._apply_updated_settings = applied_settings.append
+
+    controller.toggle_settings_sidebar()
+
+    assert not ui.settingsSidebar.isHidden()
+    assert ui.openSettingsButton.text() == "Hide Settings"
+
+    ui.sidebarSettingsEditor.rate_combo.setCurrentText("slow")
+    controller.apply_sidebar_settings()
+
+    assert applied_settings
+    assert applied_settings[-1].speaking_rate == "slow"
+
+    controller.hide_settings_sidebar()
+
+    assert ui.settingsSidebar.isHidden()
+    assert ui.openSettingsButton.text() == "Settings"
 
 
 def test_loading_state_toggles_real_import_dialog_buttons(qtbot):


### PR DESCRIPTION
## Summary

This PR closes #72 and #73 by completing the main-window layout updates around settings access and output visibility, then adds the follow-up UX polish requested during review.

Changes include:

- Added a collapsible Settings sidebar that can be opened from `Tools > Settings` or the Settings button without leaving the editor.
- Reused the shared settings editor so sidebar apply behavior stays consistent with the existing settings flow.
- Moved the output summary out of the content area and into a right-aligned status bar summary.
- Made `Recent Audio` collapsible with a compact `-` / `+` control on the same line as the section caption.
- Tightened group-box padding, narrowed inner spacing, and sharpened box corners slightly in `app/assets/styles/styles.qss`.
- Updated docs to reflect the current GUI, OCR/image import support, Tesseract requirement, and settings sidebar workflow.
- Removed the empty `docs/module1.rst` placeholder.

## Testing

- `poetry run pytest`
- `poetry check`
- `git diff --check`

Closes #72.
Closes #73.
